### PR TITLE
fix include for rocm 5.5.0

### DIFF
--- a/base_test.hpp
+++ b/base_test.hpp
@@ -42,14 +42,8 @@
 
 #ifndef ROC_BANDWIDTH_TEST_BASE_H_
 #define ROC_BANDWIDTH_TEST_BASE_H_
-#if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-// Hsa package with out file reorganization
-// This is for backward compatibility and will be deprecated from future release
-#include "hsa.h"
-#else
 // Hsa package with file reorganization
-#include "hsa/hsa.h"
-#endif
+#include <hsa/hsa.h>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/common.hpp
+++ b/common.hpp
@@ -48,16 +48,9 @@
 #include <vector>
 #include <cmath>
 #include <stdio.h>
-#if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-// Hsa package with out file reorganization
-// This is for backward compatibility and will be deprecated from future release
-#include "hsa.h"
-#include "hsa_ext_amd.h"
-#else
 // Hsa package with file reorganization
-#include "hsa/hsa.h"
-#include "hsa/hsa_ext_amd.h"
-#endif
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 
 using namespace std;
 

--- a/rocm_bandwidth_test.hpp
+++ b/rocm_bandwidth_test.hpp
@@ -43,14 +43,8 @@
 #ifndef __ROC_BANDWIDTH_TEST_H__
 #define __ROC_BANDWIDTH_TEST_H__
 
-#if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-// Hsa package with out file reorganization
-// This is for backward compatibility and will be deprecated from future release
-#include "hsa.h"
-#else
 // Hsa package with file reorganization
-#include "hsa/hsa.h"
-#endif
+#include <hsa/hsa.h>
 #include "base_test.hpp"
 #include "common.hpp"
 


### PR DESCRIPTION
uh since the warnings have been turned into errors, just update the header include directly