### PR TITLE
fix: [rocm/rocm_bandwidth_test] add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @bill-shuzhou-liu @dmitrii-galantsev @charis-poag-amd @oliveiradan
+


### PR DESCRIPTION
fix: [rocm/rocm_bandwidth_test] add CODEOWNERS

Code changes related to the following:
  * add CODEOWNERS to .github/

Change-Id: I719b11ad6498c09b5c6a257a912d552002525715
Signed-off-by: Oliveira, Daniel <daniel.oliveira@amd.com>

