### PR TITLE
CMAKE - Remove backwards-compat header logic for old rocm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.15)
 #
 #  Setup build environment
 #
@@ -39,7 +39,8 @@ if(WIN32)
 endif()
 
 # Flag to enable / disable verbose output.
-SET(CMAKE_VERBOSE_MAKEFILE on)
+option(CMAKE_VERBOSE_MAKEFILE "Enable verbose output" ON)
+option(CMAKE_EXPORT_COMPILE_COMMANDS "Export compile commands for linters and autocompleters" ON)
 
 # Compiler Preprocessor definitions.
 add_definitions(-DUNIX_OS)
@@ -133,42 +134,9 @@ include(utils)
 # Using find_package(has-runtime64 to find required header and library files
 # This scheme could fail when using older builds of ROCm. In such a case the
 # build system relies on user defined locations to find header and library files
-find_package(hsa-runtime64 PATHS /opt/rocm )
-if(${hsa-runtime64_FOUND})
-  # hsa-runtime config files will provide the include path via INSTALL_INTERFACE
-  message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
-  set(RBT_HSA_VERSION_MAJ ${hsa-runtime64_VERSION_MAJOR} )
-  set(RBT_HSA_VERSION_MIN ${hsa-runtime64_VERSION_MINOR} )
-  set(RBT_HSA_VERSION_PATCH ${hsa-runtime64_VERSION_PATCH} )
-  # With file reorg changes
-  # Actual header files  /opt/rocm-ver/include/hsa/
-  # Wrapper header file  /opt/rocm-ver/hsa/include/hsa/
-  # Rocm 5.3.0 will have Hsa file reorg changes. Corresponding Hsa package version is 1056300
-  # If hsa package version greater than or equal to file reorg version,use hsa/hsa.h else use hsa.h
-  math(EXPR RBT_HSA_VERSION_FILEREORG "1056300")
-  add_compile_options(-DRBT_HSA_VERSION_FILEREORG=${RBT_HSA_VERSION_FILEREORG})
-
-  if( (RBT_HSA_VERSION_MAJ GREATER 999) OR (RBT_HSA_VERSION_MIN GREATER 999) )
-    # Build will fail ,if package version is invalid
-    message(FATAL_ERROR "RBT hsa-runtime64: Too big HSA runtime version number(s)" )
-  else() # if valid hsa  package version
-     # find the hsa package version and set flat version
-    math(EXPR RBT_HSA_VERSION_FLAT  "(${RBT_HSA_VERSION_MAJ}*1000000+${RBT_HSA_VERSION_MIN}*1000+${RBT_HSA_VERSION_PATCH})" )
-    add_compile_options(-DRBT_HSA_VERSION_FLAT=${RBT_HSA_VERSION_FLAT})
-  endif()
-else()
-  message("find_package did NOT find hsa-runtime64, finding it the OLD Way")
-  message("Looking for header files in ${ROCR_INC_DIR}")
-  message("Looking for library files in ${ROCR_LIB_DIR}")
-
-  # Search for ROCr header file in user defined locations
-  # Since the search is for hsa/hsa.h and the default include is "hsa/hsa.h", this will support all version of rocm
-  find_path(ROCR_HDR hsa/hsa.h PATHS ${ROCR_INC_DIR} "/opt/rocm" PATH_SUFFIXES include REQUIRED)
-  INCLUDE_DIRECTORIES(${ROCR_HDR})
-
-  # Search for ROCr library file in user defined locations
-  find_library(ROCR_LIB ${CORE_RUNTIME_TARGET} PATHS ${ROCR_LIB_DIR} "/opt/rocm" PATH_SUFFIXES lib lib64 REQUIRED)
-endif()
+find_package(hsa-runtime64 PATHS /opt/rocm REQUIRED)
+# hsa-runtime config files will provide the include path via INSTALL_INTERFACE
+message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
 
 #
 # Set the package version for the test. It is critical that this
@@ -196,11 +164,7 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} Src)
 
 # Build and link the test program
 add_executable(${TEST_NAME} ${Src})
-if(${hsa-runtime64_FOUND})
-   target_link_libraries(${TEST_NAME} PRIVATE hsa-runtime64::hsa-runtime64)
-else()
-   target_link_libraries(${TEST_NAME} PRIVATE ${ROCR_LIB})
-endif()
+target_link_libraries(${TEST_NAME} PRIVATE hsa-runtime64::hsa-runtime64)
 target_link_libraries(${TEST_NAME} PRIVATE c stdc++ dl pthread rt)
 
 # Update linker flags to include RPATH

--- a/base_test.hpp
+++ b/base_test.hpp
@@ -42,14 +42,8 @@
 
 #ifndef ROC_BANDWIDTH_TEST_BASE_H_
 #define ROC_BANDWIDTH_TEST_BASE_H_
-#if (defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-// Hsa package with out file reorganization
-// This is for backward compatibility and will be deprecated from future release
-#include "hsa.h"
-#else
-// Hsa package with file reorganization
 #include "hsa/hsa.h"
-#endif
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/common.hpp
+++ b/common.hpp
@@ -43,22 +43,15 @@
 #ifndef ROC_BANDWIDTH_TEST_COMMON_HPP
 #define ROC_BANDWIDTH_TEST_COMMON_HPP
 
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+
 #include <stdio.h>
 
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <vector>
-#if (defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-// Hsa package with out file reorganization
-// This is for backward compatibility and will be deprecated from future release
-#include "hsa.h"
-#include "hsa_ext_amd.h"
-#else
-// Hsa package with file reorganization
-#include "hsa/hsa.h"
-#include "hsa/hsa_ext_amd.h"
-#endif
 
 using namespace std;
 

--- a/rocm_bandwidth_test.hpp
+++ b/rocm_bandwidth_test.hpp
@@ -43,16 +43,9 @@
 #ifndef __ROC_BANDWIDTH_TEST_H__
 #define __ROC_BANDWIDTH_TEST_H__
 
-#if (defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-// Hsa package with out file reorganization
-// This is for backward compatibility and will be deprecated from future release
-#include "hsa.h"
-#else
-// Hsa package with file reorganization
-#include "hsa/hsa.h"
-#endif
 #include "base_test.hpp"
 #include "common.hpp"
+#include "hsa/hsa.h"
 
 #include <chrono>
 #include <vector>


### PR DESCRIPTION
Change-Id: Ib618251c0255be2023790b5d80660c6f8b0f9fb5