### PR TITLE
Use __LINE__ rather than __COUNTER__

### DIFF
--- a/deps/work_bench/include/awb/common_utils.hpp
+++ b/deps/work_bench/include/awb/common_utils.hpp
@@ -384,7 +384,7 @@ enum class PcieThroughput_t
 // clang-format off
 #define GUARD_TOKEN_CONCATENATE_IMPL(x, y)  x##y
 #define GUARD_TOKEN_CONCATENATE(x, y)       GUARD_TOKEN_CONCATENATE_IMPL(x, y)
-#define WB_GUARD_ANONYMOUS_VAR(prefix)      GUARD_TOKEN_CONCATENATE(prefix, __COUNTER__)
+#define WB_GUARD_ANONYMOUS_VAR(prefix)      GUARD_TOKEN_CONCATENATE(prefix, __LINE__)
 // clang-format on
 
 namespace amd_work_bench::utils::scope_guard


### PR DESCRIPTION
Newer LLVM compilers warn that `__COUNTER__` is a C2y extension ( -Wc2y-extensions ). See https://github.com/llvm/llvm-project/pull/162662 . The fix is to use `__LINE__` instead. 