### PR TITLE
Merge pull request #145 from amd-mainline to develop

### DIFF
--- a/.github/scripts/configure-rocm-sdk-channel.sh
+++ b/.github/scripts/configure-rocm-sdk-channel.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+################################################################################
+# Configure ROCm SDK channel + ROCM_VERSION for build_packages_local.sh (CI).
+# Uses POSIX case for release/* refs (safe under dash/sh and bash).
+################################################################################
+set -euo pipefail
+
+GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
+
+NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-}"
+NIGHTLY_IDX="${ROCM_SDK_NIGHTLY_INDEX_URL:-}"
+[ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://therock-nightly-tarball.s3.us-east-2.amazonaws.com'
+[ -z "$NIGHTLY_IDX" ]  && NIGHTLY_IDX='https://therock-nightly-tarball.s3.amazonaws.com/index.html'
+
+REL_URL="${ROCM_SDK_RELEASE_URL:-}"
+[ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
+REL_BASE="${ROCM_SDK_RELEASE_BASE_URL:-}"
+[ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
+
+EVENT="${GITHUB_EVENT_NAME:-}"
+REF="${GITHUB_REF:-}"
+IN_VER="${INPUT_ROCM_VERSION:-}"
+VAR_VER="${VAR_ROCM_VERSION:-}"
+IN_GPU="${INPUT_GPU_FAMILY:-}"
+
+release_build() {
+  {
+    echo "ROCM_SDK_CHANNEL=release"
+    echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+    echo "ROCM_SDK_BASE_URL=$REL_BASE"
+    echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+    echo "ROCM_SDK_INDEX_URL="
+  } >> "$GITHUB_ENV"
+}
+
+nightly_build() {
+  {
+    echo "ROCM_SDK_CHANNEL=nightly"
+    echo "ROCM_SDK_RELEASE_URL="
+    echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+    echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+  } >> "$GITHUB_ENV"
+}
+
+format_build() {
+  {
+    echo "ROCM_SDK_CHANNEL=auto"
+    echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+    echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+    echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+    echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
+    echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
+    echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+  } >> "$GITHUB_ENV"
+}
+
+##
+# ROCM_VERSION: schedule clears; dispatch input wins; repo variable as fallback.
+if [ "$EVENT" = "schedule" ]; then
+  echo "ROCM_VERSION=" >> "$GITHUB_ENV"
+  echo "Scheduled run: build script will auto-fetch latest ROCm version"
+elif [ -n "$IN_VER" ]; then
+  echo "ROCM_VERSION=$IN_VER" >> "$GITHUB_ENV"
+  echo "Using workflow_dispatch ROCm version: $IN_VER"
+elif [ -n "$VAR_VER" ]; then
+  echo "ROCM_VERSION=$VAR_VER" >> "$GITHUB_ENV"
+  echo "Using repository variable ROCM_VERSION: $VAR_VER"
+fi
+
+if [ -n "$IN_GPU" ]; then
+  echo "GPU_FAMILY=$IN_GPU" >> "$GITHUB_ENV"
+fi
+
+if [ "$EVENT" = "schedule" ]; then
+  nightly_build
+  echo "ROCm SDK channel: nightly (scheduled — latest nightly)"
+elif [ "$EVENT" = "pull_request" ]; then
+  release_build
+  echo "ROCm SDK channel: release (pull request — latest X.Y.Z)"
+elif [ "$EVENT" = "push" ]; then
+  case "$REF" in
+    refs/heads/amd-mainline|refs/heads/release/*)
+      release_build
+      echo "ROCm SDK channel: release (push to amd-mainline or release/* — includes merge)"
+      ;;
+    *)
+      nightly_build
+      echo "ROCm SDK channel: nightly (push to feature branch)"
+      ;;
+  esac
+elif [ "$EVENT" = "workflow_dispatch" ]; then
+  if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
+    format_build
+    echo "ROCm SDK: manual — tarball base chosen by version format (input or vars.ROCM_VERSION)"
+  else
+    nightly_build
+    echo "ROCm SDK channel: nightly (manual, no version pin)"
+  fi
+else
+  nightly_build
+  echo "ROCm SDK channel: nightly (fallback)"
+fi

--- a/.github/scripts/rbt-s3-upload-route.sh
+++ b/.github/scripts/rbt-s3-upload-route.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+################################################################################
+# POSIX S3 path routing for RBT packages (compatible with sh/dash in containers).
+# Usage:
+#   rbt-s3-upload-route.sh upload-deb
+#   rbt-s3-upload-route.sh upload-rpm-tar
+#   rbt-s3-upload-route.sh deb-repo-prefix
+#   rbt-s3-upload-route.sh rpm-repo-prefix
+################################################################################
+set -eu
+
+BASE="rbt"
+EVENT="${GITHUB_EVENT_NAME:-}"
+REF="${GITHUB_REF:-}"
+REF_NAME="${GITHUB_REF_NAME:-}"
+RUN_NUMBER="${GITHUB_RUN_NUMBER:-0}"
+BUCKET="${AWS_S3_BUCKET:-}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+RBT_SKIP_UPLOAD="${RBT_SKIP_UPLOAD:-false}"
+RBT_IS_DEFAULT_BRANCH="${RBT_IS_DEFAULT_BRANCH:-false}"
+RBT_BRANCH_PREFIX="${RBT_BRANCH_PREFIX:-}"
+RBT_BUILD_REF_NAME="${RBT_BUILD_REF_NAME:-}"
+
+rbt_is_release_ref() {
+  case "$1" in
+    refs/heads/release/*) return 0 ;;
+  esac
+  return 1
+}
+
+rbt_resolve_route() {
+  RBT_S3_ROUTE="pr"
+  RBT_S3_DEB_PREFIX=""
+  RBT_S3_RPM_PREFIX=""
+  RBT_S3_TAR_PREFIX=""
+  RBT_APT_SUITE="rbt-nightly"
+  RBT_S3_OUTPUT_PATHS=""
+
+  if [ "$RBT_SKIP_UPLOAD" = "true" ]; then
+    RBT_S3_ROUTE="skip"
+    return 0
+  fi
+
+  if [ "$EVENT" = "schedule" ] && [ "$RBT_IS_DEFAULT_BRANCH" != "true" ]; then
+    RBT_S3_ROUTE="scheduled_branch"
+    RBT_S3_DEB_PREFIX="${RBT_BRANCH_PREFIX}/${RBT_BUILD_REF_NAME}/nightly/deb"
+    RBT_S3_RPM_PREFIX="${RBT_BRANCH_PREFIX}/${RBT_BUILD_REF_NAME}/nightly/rpm"
+    RBT_S3_TAR_PREFIX="${RBT_BRANCH_PREFIX}/${RBT_BUILD_REF_NAME}/nightly/tar"
+    RBT_S3_OUTPUT_PATHS="Ubuntu DEB|${RBT_BRANCH_PREFIX}/${RBT_BUILD_REF_NAME}/nightly/deb||CentOS/RHEL RPM|${RBT_BRANCH_PREFIX}/${RBT_BUILD_REF_NAME}/nightly/rpm||CentOS/RHEL TGZ|${RBT_BRANCH_PREFIX}/${RBT_BUILD_REF_NAME}/nightly/tar"
+    return 0
+  fi
+
+  if rbt_is_release_ref "$REF" && { [ "$EVENT" = "push" ] || [ "$EVENT" = "workflow_dispatch" ]; }; then
+    RBT_S3_ROUTE="release"
+    RBT_S3_DEB_PREFIX="release/${BASE}/deb"
+    RBT_S3_RPM_PREFIX="release/${BASE}/rpm"
+    RBT_S3_TAR_PREFIX="release/${BASE}/tar"
+    RBT_APT_SUITE="rbt-release"
+    RBT_S3_OUTPUT_PATHS="Ubuntu DEB|release/${BASE}/deb||CentOS/RHEL RPM|release/${BASE}/rpm||CentOS/RHEL TGZ|release/${BASE}/tar"
+    return 0
+  fi
+
+  if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "push" ] || [ "$EVENT" = "workflow_dispatch" ]; then
+    RBT_S3_ROUTE="nightly"
+    RBT_S3_DEB_PREFIX="nightly/${BASE}/deb"
+    RBT_S3_RPM_PREFIX="nightly/${BASE}/rpm"
+    RBT_S3_TAR_PREFIX="nightly/${BASE}/tar"
+    RBT_APT_SUITE="rbt-nightly"
+    RBT_S3_OUTPUT_PATHS="Ubuntu DEB|nightly/${BASE}/deb||CentOS/RHEL RPM|nightly/${BASE}/rpm||CentOS/RHEL TGZ|nightly/${BASE}/tar"
+    return 0
+  fi
+
+  RBT_S3_ROUTE="pr"
+  RBT_S3_DEB_PREFIX="${BASE}/${REF_NAME}/${RUN_NUMBER}/deb"
+  RBT_S3_RPM_PREFIX="${BASE}/${REF_NAME}/${RUN_NUMBER}/rpm"
+  RBT_S3_TAR_PREFIX="${BASE}/${REF_NAME}/${RUN_NUMBER}/tar"
+  RBT_S3_OUTPUT_PATHS="Ubuntu DEB|${RBT_S3_DEB_PREFIX}||CentOS/RHEL RPM|${RBT_S3_RPM_PREFIX}||TGZ|${RBT_S3_TAR_PREFIX}"
+}
+
+cmd="${1:-}"
+rbt_resolve_route
+
+case "$cmd" in
+  upload-deb)
+    if [ -z "$BUCKET" ]; then
+      echo "::warning::AWS_S3_BUCKET not set. Skipping S3 upload."
+      exit 0
+    fi
+    if [ "$RBT_S3_ROUTE" = "skip" ]; then
+      echo "Skipping S3 upload (scheduled release* branch)."
+      exit 0
+    fi
+    case "$RBT_S3_ROUTE" in
+      scheduled_branch) echo "Scheduled ACTIVE_BRANCHES build: uploading DEB to ${RBT_S3_DEB_PREFIX}" ;;
+      release)          echo "Release branch build: uploading DEB to ${RBT_S3_DEB_PREFIX}" ;;
+      nightly)          echo "Nightly/push build: uploading DEB to ${RBT_S3_DEB_PREFIX}" ;;
+      *)                echo "Uploading DEB to s3://${BUCKET}/${RBT_S3_DEB_PREFIX}/" ;;
+    esac
+    aws s3 cp ./build "s3://${BUCKET}/${RBT_S3_DEB_PREFIX}/" \
+      --recursive --exclude "*" --include "amdrocm*-rbt*.deb" --no-progress
+    echo "Listing s3://${BUCKET}/${RBT_S3_DEB_PREFIX}/"
+    aws s3 ls "s3://${BUCKET}/${RBT_S3_DEB_PREFIX}/" --human-readable || true
+    echo "bucket=${BUCKET}" >> "$GITHUB_OUTPUT"
+    echo "paths=Ubuntu DEB|${RBT_S3_DEB_PREFIX}" >> "$GITHUB_OUTPUT"
+    echo "Done."
+    ;;
+  upload-rpm-tar)
+    if [ -z "$BUCKET" ]; then
+      echo "::warning::AWS_S3_BUCKET not set. Skipping S3 upload."
+      exit 0
+    fi
+    if [ "$RBT_S3_ROUTE" = "skip" ]; then
+      echo "Skipping S3 upload (scheduled release* branch)."
+      exit 0
+    fi
+    case "$RBT_S3_ROUTE" in
+      scheduled_branch) echo "Scheduled ACTIVE_BRANCHES build: uploading to ${RBT_S3_RPM_PREFIX} and ${RBT_S3_TAR_PREFIX}" ;;
+      release)          echo "Release branch build: uploading to ${RBT_S3_RPM_PREFIX} and ${RBT_S3_TAR_PREFIX}" ;;
+      nightly)          echo "Nightly/push build: uploading to ${RBT_S3_RPM_PREFIX} and ${RBT_S3_TAR_PREFIX}" ;;
+      *)                echo "Uploading to s3://${BUCKET}/${RBT_S3_RPM_PREFIX}/" ;;
+    esac
+    aws s3 cp ./build "s3://${BUCKET}/${RBT_S3_RPM_PREFIX}/" \
+      --recursive --exclude "*" --include "amdrocm*-rbt*.rpm" --no-progress
+    aws s3 cp ./build "s3://${BUCKET}/${RBT_S3_TAR_PREFIX}/" \
+      --recursive --exclude "*" --include "amdrocm*-rbt*.tar.gz" --no-progress
+    echo "Listing s3://${BUCKET}/${RBT_S3_RPM_PREFIX}/"
+    aws s3 ls "s3://${BUCKET}/${RBT_S3_RPM_PREFIX}/" --human-readable || true
+    echo "Listing s3://${BUCKET}/${RBT_S3_TAR_PREFIX}/"
+    aws s3 ls "s3://${BUCKET}/${RBT_S3_TAR_PREFIX}/" --human-readable || true
+    echo "bucket=${BUCKET}" >> "$GITHUB_OUTPUT"
+    echo "paths=CentOS/RHEL RPM|${RBT_S3_RPM_PREFIX}||CentOS/RHEL TGZ|${RBT_S3_TAR_PREFIX}" >> "$GITHUB_OUTPUT"
+    echo "Done."
+    ;;
+  deb-repo-prefix)
+    echo "$RBT_S3_DEB_PREFIX"
+    echo "$RBT_APT_SUITE"
+    ;;
+  rpm-repo-prefix)
+    echo "$RBT_S3_RPM_PREFIX"
+    ;;
+  *)
+    echo "Usage: $0 upload-deb|upload-rpm-tar|deb-repo-prefix|rpm-repo-prefix" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/README_NIGHTLY_TESTS.md
+++ b/.github/workflows/README_NIGHTLY_TESTS.md
@@ -1,0 +1,452 @@
+# RBT Nightly Tests Workflow
+
+This document describes [`.github/workflows/rbt-nightly-tests.yml`](./rbt-nightly-tests.yml),
+which picks up the **latest RBT tarball** from the index URL configured in
+`vars.RBT_TARBALL_INDEX_URL` (e.g. `https://repo.amd.com/rocm/rbt/tarball/`)
+once per day, copies it to a **configurable remote target node** over SSH,
+installs it there, and runs bandwidth tests (healthcheck, P2P, topology) on that node.
+
+The GitHub Actions runner ("RBT Runner") is only an **orchestrator** — it
+doesn't need a GPU or ROCm installed locally. All RBT install, binary
+verification, and test execution happens on the target node. The target node
+is configurable so the same workflow can be pointed at any GPU host without
+code changes.
+
+## What it does
+
+```
+schedule / workflow_run / manual
+    │
+    ▼
+detect-tarball              [utility runner]
+    │  curl $RBT_TARBALL_INDEX_URL → pick newest amdrocm*-rbt-*.tar.gz
+    ▼
+prepare-test-context        [utility runner]
+    │  rbt_nightly_test.sh validate-config → paths + remote work dir
+    ▼
+install-rbt-on-target       [test runner]  ──ssh──▶  [target GPU node]
+    │  rbt_nightly_test.sh: setup-ssh, verify-rocm, download, copy,
+    │                        install-rbt, verify-rbt-binary
+    ▼
+run-rbt-tests               [test runner]  ──ssh──▶  [target GPU node]
+    │  rbt_nightly_test.sh: run-tests (healthcheck, p2p, topology),
+    │  collect-logs, capture-versions
+    │  upload intermediate logs artifact; cleanup remote work dir
+    ▼
+create-test-report          [utility runner]
+    │  rbt_nightly_test.sh build-report → SUMMARY.md + final artifact
+    ▼
+artifact: rbt-nightly-report-<run_id>
+```
+
+Install, test, and report logic lives in [`rbt_nightly_test.sh`](../../rbt_nightly_test.sh)
+at the repo root — the same split as `build-relocatable-packages.yml` +
+`build_packages_local.sh`.
+
+## Triggers
+
+| Trigger | Cadence | What fires |
+|---|---|---|
+| `schedule` | `0 15 * * *` UTC daily (08:00 PST / 07:00 PDT) | Polls the tarball index and always runs install + tests, even when the latest tarball filename matches the previous run (a notice is logged when unchanged). |
+| `workflow_run` | After **Build Relocatable Packages** completes | Runs only when that workflow's overall conclusion is **success**. No changes to the build workflow are required. |
+| `workflow_dispatch` | Manual | Always runs. Supports overriding the tarball URL and **retargeting at any node** without editing the workflow. |
+
+The cron deliberately runs after AMD's typical nightly publish window;
+adjust the cron string in the workflow if your publish cadence is different.
+
+## Manual dispatch inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `tarball_url` | _(empty)_ | If set, the workflow downloads this exact URL instead of scraping the index. Useful for re-running an older build. |
+| `target_node` | _(empty → `secrets.RBT_TARGET_NODE`)_ | Hostname or IP of the node to install RBT on and run tests against. **This is the value that retargets the test execution.** Stored as a secret so the lab node identity isn't visible in repo settings or run logs (GitHub Actions automatically masks secret values as `***` in step output). |
+| `target_user` | _(empty → `secrets.RBT_TARGET_USER`; if both are unset, SSH defaults to the orchestrator runner's local user)_ | SSH user on the target node. Must have `NOPASSWD` sudo on the target (see prerequisites). Stored as a secret so the lab account name isn't visible in repo settings or run logs (GitHub Actions automatically masks secret values as `***` in step output). |
+| `remote_work_dir` | _(empty → `vars.RBT_REMOTE_WORK_DIR`, then `/tmp/rbt-nightly-<run_id>`)_ | Working dir on the target node where the tarball is staged, logs are written, and which gets `rm -rf`'d at the end. |
+| `target_rocm_path` | _(empty → `vars.RBT_TARGET_ROCM_PATH`)_ — **required**, no hard-coded default | Absolute path to the ROCm tarball install root on the target node. This is the directory containing `bin/rocminfo`, `bin/amd-smi`, `lib/`, `lib/llvm/lib/`, and `lib/rocm_sysdeps/lib/` (the layout produced by the ROCm tarball install method). The workflow fails fast in the validate step if neither the input nor the variable is set. |
+
+Workflow inputs **win over repo variables**, so individual `workflow_dispatch`
+runs can be retargeted from the Actions UI without changing repo settings.
+
+Example — point a single run at a specific node:
+
+```bash
+gh workflow run rbt-nightly-tests.yml \
+  -f tarball_url="<INDEX_URL>/amdrocm7-rbt-2.6.2-r0711.20260609-Linux.tar.gz" \
+  -f target_node="<HOST_OR_IP>" \
+  -f target_user="<USER>"
+```
+
+Example — keep the default tarball but run on a different host today:
+
+```bash
+gh workflow run rbt-nightly-tests.yml -f target_node="<HOST_OR_IP>"
+```
+
+Example — point at a specific ROCm install on a multi-ROCm host:
+
+```bash
+gh workflow run rbt-nightly-tests.yml \
+  -f target_node="<HOST_OR_IP>" \
+  -f target_rocm_path="<ROCM_INSTALL_PATH>"
+```
+
+## Repository configuration
+
+**Variables** (Settings → Secrets and variables → Actions → Variables):
+
+| Name | Required? | Purpose |
+|---|---|---|
+| `RBT_TARBALL_INDEX_URL` | **Required** | Directory listing scraped for the latest tarball, e.g. `https://repo.amd.com/rocm/rbt/tarball/`. No fallback — the workflow fails fast if unset and no `tarball_url` input is supplied. |
+| `RBT_REMOTE_WORK_DIR` | optional (default `/tmp/rbt-nightly-<run_id>`) | Working dir on the target node. Cleared with `rm -rf` at the end of the job. |
+| `RBT_TARGET_ROCM_PATH` | **Required** *(unless every run sets `target_rocm_path` input)* | Absolute path to the ROCm tarball install root on the target node — the directory that contains `bin/rocminfo`, `bin/amd-smi`, `lib/`, `lib/llvm/lib/`, and `lib/rocm_sysdeps/lib/`. The workflow doesn't assume any conventional path (no `/opt/rocm` default), since tarball installs land wherever you extracted them. |
+| `RBT_TEST_RUNNER_LABEL` | optional (default `self-hosted`) | Label of the GitHub runner that orchestrates the workflow. The runner doesn't need a GPU or ROCm — it just needs `ssh`, `scp`, and `curl`. |
+
+**Secrets** (Settings → Secrets and variables → Actions → Secrets):
+
+| Name | Required? | Purpose |
+|---|---|---|
+| `RBT_TARGET_NODE` | **Required** *(unless every run sets `target_node` input)* | Hostname or IP of the node where RBT is installed and tests run. Stored as a secret so the lab node identity isn't visible in repo Variables or in run logs — GitHub Actions automatically masks secret values as `***` wherever they appear in step output. Workflow fails fast on `schedule` if neither this secret nor `target_node` input is set. |
+| `RBT_TARGET_USER` | optional (no hard-coded default) | SSH user on the target node. If unset and `target_user` input is empty, the SSH client falls back to the orchestrator runner's local user — set this secret explicitly to avoid surprises. Stored as a secret so the lab account name isn't visible in repo settings or run logs (auto-masked as `***`). |
+| `RBT_TARGET_SSH_KEY` | **Required** | Private SSH key (OpenSSH or PEM format) authorized on the target node for `RBT_TARGET_USER`. Written to `$RUNNER_TEMP/rbt_target_key` for the duration of the job and scrubbed in the cleanup step. |
+
+## How the latest tarball is picked
+
+The `detect-tarball` job does (with `$INDEX_URL` = `vars.RBT_TARBALL_INDEX_URL`):
+
+```bash
+curl -sL "$INDEX_URL" \
+  | grep -oE 'amdrocm[0-9]*-rbt-[0-9A-Za-z._\-]+-Linux\.tar\.gz' \
+  | sort -uV \
+  | tail -n 1
+```
+
+The regex matches any `amdrocm<N>-rbt-…-Linux.tar.gz` filename in the
+directory-listing HTML. `sort -V` is GNU "version sort" so version
+suffixes like `2.6.2-r0711-9` and `2.6.2-r0711-100` compare correctly. The
+**lexicographically largest by version** is selected.
+
+## How the tarball is installed (on the target node)
+
+The runner derives the ROCm major version from the tarball filename
+(e.g. `amdrocm7-rbt-2.6.2-r0711.20260609-Linux.tar.gz` → `7`), combines it with
+`TARGET_ROCM_PATH` (which selects *which* ROCm install to use), writes
+the derived paths to `$GITHUB_ENV`, then SSHes into the target with those
+values exported so the install runs against the matching `extras-<major>`
+directory under the chosen ROCm. The same workflow handles ROCm 6, 7,
+etc., and any version inside `7.x` without code changes:
+
+```bash
+# On the runner (validate-config step):
+# Parsed from $TARBALL_NAME via [[ "$TARBALL_NAME" =~ ^amdrocm([0-9]+)- ]]
+ROCM_MAJOR=7
+# INSTALL_DIR is always /opt/rocm/extras-<major>/ — it's where the RBT
+# tarball gets extracted. This is decoupled from TARGET_ROCM_PATH so the
+# install location matches the manual command verbatim regardless of
+# which ROCm install the workflow is told to run *against*.
+INSTALL_DIR=/opt/rocm/extras-${ROCM_MAJOR}              # /opt/rocm/extras-7
+RBT_BIN=${INSTALL_DIR}/bin/rocm_bandwidth_test
+
+# TARGET_ROCM_PATH (from inputs.target_rocm_path / vars.RBT_TARGET_ROCM_PATH;
+# required, no default) is *where the ROCm runtime libraries live*. Set
+# the repo variable to the absolute install root of the ROCm tarball you
+# want RBT to run against (the directory that contains bin/, lib/, etc.).
+
+# On the target node (install-rbt step), via SSH:
+# sudo is used only when $INSTALL_DIR isn't user-writable. /opt/rocm/* is
+# typically root-owned so this picks up sudo -n automatically.
+mkdir -p "$INSTALL_DIR"     # (with `sudo -n` if needed)
+tar -xzf "$REMOTE_WORK_DIR/pkg/<tarball>.tar.gz" -C "$INSTALL_DIR"
+
+# LD_LIBRARY_PATH is wired off INSTALL_DIR (for RBT's own libs) plus the
+# three TheRock-style subdirs of TARGET_ROCM_PATH (matches the official
+# ROCm tarball-install docs). This is what makes a non-/opt/rocm
+# TARGET_ROCM_PATH actually do something useful.
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+
+"$RBT_BIN" --version
+```
+
+### Install location vs. ROCm runtime path
+
+Two paths in the workflow look similar but mean very different things, and
+keeping them straight is what makes the multi-ROCm-host case work:
+
+| Variable | What it is | Default | How to override |
+|---|---|---|---|
+| `INSTALL_DIR` | Where the RBT tarball gets extracted on the target node. Always under `/opt/rocm/`, matching the manual command. | `/opt/rocm/extras-${ROCM_MAJOR}` | Not configurable by design — the install location is canonical, decoupled from where ROCm itself lives. |
+| `TARGET_ROCM_PATH` | Where the ROCm runtime libraries live (the directory containing `bin/`, `lib/`, `lib/llvm/lib/`, `lib/rocm_sysdeps/lib/`). Drives `LD_LIBRARY_PATH`, the prereq-check probe, and the version row in the report. | **(no default — required)** | `inputs.target_rocm_path` (workflow_dispatch) or `vars.RBT_TARGET_ROCM_PATH` (repo Variables tab). Workflow fails fast in the validate step if neither is set. |
+
+This split exists because hosts that have multiple ROCm installs side-by-side
+(or that installed ROCm via a TheRock tarball under `$HOME`) almost never
+keep the runtime libs at `/opt/rocm/lib/`. The workflow needs to know where
+`/lib/`, `/lib/llvm/lib/`, and `/lib/rocm_sysdeps/lib/` actually are; the
+install location of RBT itself should not — and does not — care.
+
+The runtime `LD_LIBRARY_PATH` for every step that executes `rocm_bandwidth_test`
+(install, ldd-verify, tests, report `--version` query) is:
+
+```bash
+LD_LIBRARY_PATH=$INSTALL_DIR/lib:$TARGET_ROCM_PATH/lib/rocm_sysdeps/lib:$TARGET_ROCM_PATH/lib/llvm/lib:$TARGET_ROCM_PATH/lib:$LD_LIBRARY_PATH
+```
+
+### TheRock-style tarball ROCm installs
+
+The [official ROCm 7.12+ "tarball" install method](https://rocm.docs.amd.com/en/7.12.0-preview/install/rocm.html?fam=instinct&gpu=mi350x&os=ubuntu&os-version=24.04&i=tar)
+doesn't drop ROCm under `/opt/rocm-<ver>/`. Instead you extract a
+single distribution archive (e.g.
+`therock-dist-linux-<arch>-dcgpu-<version>.tar.gz`) into an
+arbitrary directory, set `ROCM_PATH=$(pwd)/install`, and source the
+env. So the layout looks like:
+
+```
+/home/<user>/<wherever-you-ran-tar>/install/
+├── bin/                     ← rocm-smi, rocminfo, hipcc, …
+├── lib/
+│   ├── rocm_sysdeps/lib/    ← ROCm runtime libs live HERE in TheRock builds
+│   └── llvm/lib/
+├── share/
+└── …
+```
+
+This works with the workflow as-is, with two things to be aware of:
+
+1. **Find the absolute path of the install on the target node** — there's no canonical location, you pick it at install time. Either ask whoever installed it, or search:
+   ```bash
+   ssh <USER>@<HOST_OR_IP> '
+     for cand in ~/install ~/*/install ~/rocm*/install /opt/therock*/install; do
+       [ -x "$cand/bin/rocminfo" ] && echo "  found ROCm install: $cand"
+     done
+   '
+   ```
+2. **Pass that absolute path as `target_rocm_path`.** Example:
+   ```bash
+   gh workflow run rbt-nightly-tests.yml \
+     -f target_node=<HOST_OR_IP> \
+     -f target_rocm_path=$HOME/<wherever-you-extracted>/install
+   ```
+
+What the workflow handles automatically for tarball installs:
+
+- The install step **skips `sudo`** when the destination is user-writable (TheRock installs in `$HOME` don't need root); only system `/opt/rocm-*` installs trigger `sudo -n`.
+- The prereq check invokes `${TARGET_ROCM_PATH}/bin/rocminfo` and `${TARGET_ROCM_PATH}/bin/amd-smi version` directly by absolute path. TheRock tarball binaries have RPATH/RUNPATH baked in relative to `${TARGET_ROCM_PATH}/lib`, so they resolve their own ROCm libs without needing `PATH` or `LD_LIBRARY_PATH` setup.
+
+`sudo -n` is non-interactive — it fails fast instead of hanging if
+`NOPASSWD` isn't configured. There's no PTY over the SSH channel anyway,
+so an interactive sudo prompt would deadlock the job.
+
+The step fails fast if the filename doesn't match `^amdrocm<digits>-`, or
+if `$RBT_BIN` isn't executable after extraction.
+
+### Prerequisites
+
+**On the GitHub runner (orchestrator):**
+
+- `ssh`, `scp`, `ssh-keyscan`, and `curl` on `PATH`.
+- Network egress to:
+  - the host serving `vars.RBT_TARBALL_INDEX_URL` (typically port 443),
+  - the target node (port 22 — or wherever its sshd listens, configurable in the SSH config block of the workflow).
+- The runner does **not** need a GPU, ROCm, or `sudo`.
+
+**On the target node** (all enforced by the **Pre-flight ROCm checks** below — the workflow fails fast if any are missing):
+
+- SSH server reachable from the runner, with the public counterpart of `secrets.RBT_TARGET_SSH_KEY` authorized for `$TARGET_USER`.
+- `$TARGET_USER` has **`NOPASSWD` sudo** for `mkdir` + `tar` into `/opt/rocm/extras-<major>` — the install step uses `sudo -n` (when the path isn't user-writable) and aborts otherwise.
+- A ROCm tarball install at `$TARGET_ROCM_PATH` (configured via `vars.RBT_TARGET_ROCM_PATH` or the per-run `target_rocm_path` input) that provides at least `bin/rocminfo` and `bin/amd-smi`. The RBT tarball only ships RBT, not the rest of ROCm, so the runtime libs under `$TARGET_ROCM_PATH/lib`, `$TARGET_ROCM_PATH/lib/llvm/lib`, and `$TARGET_ROCM_PATH/lib/rocm_sysdeps/lib` must be present.
+- Working kernel driver (`amdgpu`) and at least one GPU enumerated by `rocminfo` / `amd-smi`.
+
+## Pre-flight ROCm checks
+
+Before downloading or installing the tarball, the workflow runs **`Verify ROCm prerequisites on target node`** over SSH. It's deliberately minimal — two probes against the actual install at `$TARGET_ROCM_PATH`:
+
+| Sub-check | Action on failure | Catches |
+|---|---|---|
+| `$TARGET_ROCM_PATH` directory exists | hard fail (`exit 1`) | ROCm not installed on target, or the configured path is wrong (typo, missing trailing component, etc.) |
+| `$TARGET_ROCM_PATH/bin/rocminfo` exits 0 | hard fail (via `set -euo pipefail`) | Driver not loaded, no GPU exposed, runtime libs under `$TARGET_ROCM_PATH/lib` missing/broken, group permissions wrong |
+| `$TARGET_ROCM_PATH/bin/amd-smi version` exits 0 | hard fail | `amd-smi` missing from the install, ROCm SMI library mismatch, or driver/runtime broken |
+
+Both binaries are invoked by absolute path (`${TARGET_ROCM_PATH}/bin/...`), so the workflow doesn't depend on `PATH` or `LD_LIBRARY_PATH` being set up — the binaries' baked-in RPATH/RUNPATH resolves the runtime libs from `${TARGET_ROCM_PATH}/lib`. If either probe fails, the step fails fast with the binary's own error message in the log, which is usually more diagnostic than anything the workflow could add on top.
+
+A typical successful log (with `target_rocm_path=<ROCM_INSTALL_PATH>`):
+
+```
+=== System ===
+Linux <hostname> 6.x.x-x-generic ...
+
+=== Target ROCm path: <ROCM_INSTALL_PATH> ===
+
+=== <ROCM_INSTALL_PATH>/bin/rocminfo ===
+ROCk module version <X.Y> is loaded
+HSA Agents
+==========
+Agent 1
+  Name:                    AMD Instinct ...
+  ...
+Agent 2..N: (one per GPU)
+
+=== <ROCM_INSTALL_PATH>/bin/amd-smi version ===
+AMDSMI Tool: <X.Y.Z> | AMDSMI Library version: <X.Y.Z> | ROCm version: <ROCM_VERSION>
+
+::notice::ROCm prerequisites OK on target node at <ROCM_INSTALL_PATH>
+```
+
+After install, **`Verify RBT binary library resolution on target node`** runs `ldd "$RBT_BIN"` over SSH (where `$RBT_BIN` = `/opt/rocm/extras-${ROCM_MAJOR}/bin/rocm_bandwidth_test`) and **hard-fails** the job if any library shows up as `not found`. This prevents the workflow from spending time on bandwidth tests only to discover a `dlopen` error in the log. The full `ldd` output is printed for diagnostic purposes.
+
+### Manual one-liner (validate a candidate target node)
+
+To verify a node is viable before pointing the workflow at it, SSH into the candidate and run the same two probes the workflow runs (substituting `<ROCM_INSTALL_PATH>` with what you plan to set `target_rocm_path` to):
+
+```bash
+ROCM_PATH=<ROCM_INSTALL_PATH>
+set -euo pipefail
+[ -d "$ROCM_PATH" ] || { echo "$ROCM_PATH does not exist"; exit 1; }
+"$ROCM_PATH/bin/rocminfo"
+"$ROCM_PATH/bin/amd-smi" version
+sudo -n true 2>/dev/null && echo "NOPASSWD sudo OK" || echo "warn: sudo requires password (install step will fail)"
+echo "Target node OK"
+```
+
+If both `rocminfo` and `amd-smi version` exit zero, the workflow's prereq step will pass on this node.
+
+## The tests
+
+Three tests run sequentially on the target node (with `$RBT_BIN` =
+`/opt/rocm/extras-${ROCM_MAJOR}/bin/rocm_bandwidth_test`). Each is
+executed over SSH with `set +e` so a failure in one test does not skip
+the remaining ones — all three results are captured independently.
+
+```bash
+"$RBT_BIN" run transferbench healthcheck --verbose
+"$RBT_BIN" run transferbench p2p --size=256MB --iterations=10
+"$RBT_BIN" run transferbench topology
+```
+
+Each command's stdout/stderr is captured to a separate log file on the
+target node (`healthcheck.log`, `p2p.log`, `topology.log`), then the
+**`Collect logs from target node`** step `scp`s all logs back to `./reports/`
+on the runner. Each exit code is propagated through SSH and recorded in a
+step output. The workflow is marked failed in `create-test-report` if any
+test exited non-zero.
+
+## Test report
+
+After tests finish and logs are collected, the `Build test report`
+step generates `reports/SUMMARY.md` (also written to the GitHub job summary),
+e.g.:
+
+```markdown
+# RBT Nightly Test Report
+
+| Field | Value |
+|---|---|
+| Run | `1234567890` |
+| Trigger | `schedule` |
+| Target ROCm path | `<ROCM_INSTALL_PATH>` (version `<ROCM_VERSION>`) |
+| Remote work dir | `/tmp/rbt-nightly-1234567890` |
+| Tarball | `amdrocm7-rbt-2.6.2-r0711.20260609-Linux.tar.gz` |
+| Source URL | `$RBT_TARBALL_INDEX_URL/amdrocm7-rbt-2.6.2-r0711.20260609-Linux.tar.gz` |
+| RBT version | `rocm_bandwidth_test 2.6.2` |
+| Overall result | **PASS** |
+
+## Results
+
+| Test         | Command                                                                    | Result | Exit | Started (UTC)        | Ended (UTC)          |
+|--------------|----------------------------------------------------------------------------|:------:|-----:|----------------------|----------------------|
+| Healthcheck  | `rocm_bandwidth_test run transferbench healthcheck`                        | PASS   |    0 | 2026-06-09T15:10:12Z | 2026-06-09T15:12:45Z |
+| P2P Bandwidth| `rocm_bandwidth_test run transferbench p2p --size=256MB --iterations=10`   | PASS   |    0 | 2026-06-09T15:12:46Z | 2026-06-09T15:18:03Z |
+| Topology     | `rocm_bandwidth_test run transferbench topology`                           | PASS   |    0 | 2026-06-09T15:18:04Z | 2026-06-09T15:19:22Z |
+```
+
+The full artifact contents:
+
+```
+rbt-nightly-report-<run_id>/
+├── SUMMARY.md
+├── healthcheck.log
+├── p2p.log
+└── topology.log
+```
+
+Artifact retention is 30 days.
+
+## GitHub runner vs target node
+
+The `run-rbt-tests` job runs on `${{ vars.RBT_TEST_RUNNER_LABEL || 'self-hosted' }}`,
+but this runner only orchestrates — it doesn't need a GPU or ROCm. You can:
+
+- Reuse an existing self-hosted runner that already has SSH access to the lab.
+- Use a small purpose-built orchestration runner (any Linux box with `ssh`/`scp`/`curl`).
+- In principle, use a GitHub-hosted `ubuntu-latest` runner — but that requires the target node to be reachable from GitHub's hosted runner IPs, which usually isn't the case for lab hosts behind a VPN/bastion.
+
+The **target node** is what needs the GPU, ROCm, and `NOPASSWD` sudo. It does **not** need to be a registered GitHub runner.
+
+If the chosen orchestrator runner is busy with another job, this workflow's
+`concurrency:` group (`rbt-nightly-${{ github.workflow }}`,
+`cancel-in-progress: false`) will queue the run rather than cancel the
+running one.
+
+## Verifying the pipeline end-to-end
+
+After committing the workflow file to `amd-mainline`, the fastest sanity check
+is:
+
+```bash
+gh workflow run rbt-nightly-tests.yml
+```
+
+Watch the Actions tab for:
+
+1. `detect-tarball` resolves a tarball URL (`Latest tarball : amdrocm<N>-rbt-…`).
+2. `prepare-test-context` job prints the resolved `Target node`, `Target ROCm path`, `Remote work dir`, and `Expected RBT binary` path.
+3. `install-rbt-on-target` job picks up on your orchestrator runner.
+4. **Setup SSH for target node** prints the target's `hostname` / `id` / `uptime` from the connectivity probe.
+5. **Verify ROCm prerequisites on target node** prints `::notice::ROCm prerequisites OK on target node at <TARGET_ROCM_PATH>`.
+6. **Install RBT on target node** prints the detected `ROCM_MAJOR`, the chosen `Target ROCm path`, and `Installed RBT at: /opt/rocm/extras-<N>/bin/rocm_bandwidth_test`.
+7. **Verify RBT binary library resolution on target node** prints `::notice::RBT binary's library dependencies resolved OK on target.`
+8. `run-rbt-tests` job: all three test steps complete; the run summary shows the results table with PASS/FAIL per test.
+
+## Debugging a failed run
+
+| Symptom | Likely cause |
+|---|---|
+| `detect-tarball` job exits with `vars.RBT_TARBALL_INDEX_URL is not set` | The required variable is unset. Set it in the repo Variables, or pass `tarball_url` via `workflow_dispatch`. |
+| `detect-tarball` job exits with "Could not resolve a tarball URL" | The index page returned no matches. Verify the URL in `vars.RBT_TARBALL_INDEX_URL` returns at least one `amdrocm*-rbt-*-Linux.tar.gz` link. |
+| `install-rbt-on-target` job stuck "Queued" | No orchestrator runner online with the label in `vars.RBT_TEST_RUNNER_LABEL`. |
+| **validate-config** fails: `No target node configured` | Neither `inputs.target_node` nor `secrets.RBT_TARGET_NODE` is set. Add the secret in Settings → Secrets and variables → Actions → Secrets, or pass `target_node` via `workflow_dispatch`. |
+| **setup-ssh** fails: `SSH_PRIVATE_KEY is not set` | The required secret `RBT_TARGET_SSH_KEY` is missing. Add the private SSH key as a repo secret. |
+| **setup-ssh** fails: `Permission denied (publickey)` | The key in `RBT_TARGET_SSH_KEY` isn't authorized on the target node for `$TARGET_USER`, or the key format is wrong. Verify by `ssh -i <key> $TARGET_USER@$TARGET_NODE hostname` from a workstation. |
+| **setup-ssh** fails: `Connection timed out` / `Connection refused` | Network reachability problem between the orchestrator runner and the target node. Check firewall / VPN / bastion routing. |
+| **Verify ROCm prerequisites on target node** fails: `<TARGET_ROCM_PATH> does not exist on the target node` | The configured `target_rocm_path` / `vars.RBT_TARGET_ROCM_PATH` doesn't point at a real directory on the target. Verify by `ssh <USER>@<HOST_OR_IP> 'ls -d <TARGET_ROCM_PATH>'`. |
+| **Verify ROCm prerequisites on target node** fails: `<TARGET_ROCM_PATH>/bin/rocminfo: No such file or directory` | The install at `$TARGET_ROCM_PATH` is incomplete — missing `bin/rocminfo`. Pick a different `target_rocm_path` or reinstall ROCm at the configured path. |
+| **Verify ROCm prerequisites on target node** fails: `rocminfo` exits non-zero | Driver issue or runtime libs missing. Common causes: `amdgpu` kernel driver not loaded (`lsmod \| grep amdgpu`, then `sudo modprobe amdgpu`); `$TARGET_USER` not in `video`/`render` groups; `$TARGET_ROCM_PATH/lib` missing or broken. |
+| **Verify ROCm prerequisites on target node** fails: `amd-smi version` exits non-zero | Either `amd-smi` is missing from `$TARGET_ROCM_PATH/bin/`, or the AMDSMI library under `$TARGET_ROCM_PATH/lib` is broken/missing. Reinstall or repoint `target_rocm_path` at a complete install. |
+| **Verify RBT binary library resolution on target node** fails: `RBT binary has unresolved library dependencies on target` | One or more libraries showed up as `not found` in `ldd` output. `LD_LIBRARY_PATH` (built from `$INSTALL_DIR/lib` + `$TARGET_ROCM_PATH/{lib,lib/llvm/lib,lib/rocm_sysdeps/lib}`) didn't cover them. Usually means `$TARGET_ROCM_PATH` is incomplete. The step's `ldd` output names the specific missing library. |
+| **Install RBT on target node** fails: `Cannot parse ROCm major version from tarball name` | The tarball doesn't match `^amdrocm<digits>-`. Either pin a correctly-named tarball with `tarball_url`, or fix the upstream filename. |
+| **Install RBT on target node** fails: `sudo: a password is required` | `$TARGET_USER` doesn't have `NOPASSWD` sudo on the target. Add a sudoers entry permitting `mkdir` and `tar` into `/opt/rocm/extras-*` without a password. |
+| **Install RBT on target node** fails: `rocm_bandwidth_test binary not found or not executable` | The tarball isn't rooted at `./bin/`, `./lib/`, etc. Inspect the step log (`ls -la` output) to see the actual layout. |
+| **run-tests** healthcheck exits non-zero immediately (after both verify steps passed) | RBT plugin dependency missing on the target (e.g. `libnuma1`). Check `healthcheck.log` in the artifact for the specific error. |
+| **Collect logs from target node** warns: `No log files retrieved from target node` | The test steps exited so early they didn't produce any output, or `$REMOTE_WORK_DIR` was wiped. Inspect the test-step logs in the run UI for the original error. |
+| Cron skipped a day | GitHub may delay or drop schedules under high load. Run once manually via `workflow_dispatch` to validate. |
+
+## Retargeting at a different node
+
+There are three ways to point the workflow at a different node, in increasing order of permanence:
+
+1. **Single run, from the Actions UI:** Run workflow → fill in `target_node` and `target_rocm_path` (and optionally `target_user` / `remote_work_dir`). Anything left blank falls back to the matching repo configuration value — `target_node` and `target_user` read from the **secrets** `RBT_TARGET_NODE` / `RBT_TARGET_USER` (both masked as `***` in run logs); `target_rocm_path` / `remote_work_dir` read from repo Variables. `target_node` and `target_rocm_path` have no hard-coded defaults — the workflow fails fast if neither input nor stored value is set for either.
+2. **Single run, from `gh` CLI:**
+   ```bash
+   gh workflow run rbt-nightly-tests.yml \
+     -f target_node="<host-or-ip>" \
+     -f target_rocm_path="<ROCM_INSTALL_PATH>"
+   ```
+3. **Permanent change:** update repo secrets `RBT_TARGET_NODE` / `RBT_TARGET_USER` and repo variable `RBT_TARGET_ROCM_PATH` (and optionally repo variable `RBT_REMOTE_WORK_DIR`). All subsequent scheduled and manual runs will pick these up unless an input overrides them.
+
+The same `RBT_TARGET_SSH_KEY` secret is reused across nodes — make sure the
+public counterpart of that key is added to `$TARGET_USER`'s `~/.ssh/authorized_keys`
+on **every** node you intend to point the workflow at.
+
+## References
+
+- [ROCm Bandwidth Test source](../../README.md)
+- [`build-relocatable-packages.yml`](./build-relocatable-packages.yml) and [`README_BUILD_PACKAGES.md`](./README_BUILD_PACKAGES.md) — the upstream packaging pipeline that produces these tarballs
+- [GitHub Actions: scheduled events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
+- [GitHub Actions: encrypted secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) — for `RBT_TARGET_SSH_KEY`

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -1,22 +1,35 @@
 name: Build Relocatable Packages
 
+# CI/CD pipeline for building and distributing ROCm Bandwidth Test packages.
+#
+# This workflow:
+# - Builds .deb, .rpm, and .tar.gz packages for multiple platforms
+# - Uploads packages to S3 with routing:
+#   - release/* → s3://bucket/release/rbt/{deb,rpm,tar}/
+#   - nightly   → s3://bucket/nightly/rbt/{deb,rpm,tar}/
+#   - PRs       → s3://bucket/rbt/<ref>/<run>/<platform>/
+# - Generates APT/YUM repository metadata for release/nightly channels
+#
+# For full hardware validation with GPU bandwidth testing, see:
+# rbt-nightly-tests.yml (consumes tarballs from s3://bucket/nightly/rbt/tar/)
+
 on:
   push:
     branches:
-      - amd-staging
+      - develop
       - amd-mainline
       - 'release/**'
   pull_request:
     branches:
-      - amd-staging
+      - develop
       - amd-mainline
   schedule:
-    # Run daily at 5:00 AM PST (13:00 UTC; PST is UTC-8)
+    # Run daily at 1:00 PM UTC (nightly builds)
     - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:
       rocm_version:
-        description: 'ROCm version (empty = auto-fetch latest from TheRock)'
+        description: 'Optional pin — empty uses latest nightly (unless vars.ROCM_VERSION set). Release X.Y.Z vs nightly x.y.za… selects tarball host by format.'
         required: false
         default: ''
       gpu_family:
@@ -29,80 +42,241 @@ on:
           - gfx110X-all
           - gfx1151
           - gfx120X-all
-        default: 'gfx110X-all'
+        default: 'gfx94X-dcgpu'
 
 permissions:
   contents: read
   id-token: write
 
 env:
-  ROCM_VERSION: ${{ vars.ROCM_VERSION || '7.11.0a20260121' }}
-  GPU_FAMILY: ${{ vars.GPU_FAMILY || 'gfx110X-all' }}
+  # Leave unset unless you pin a version via repo variable or workflow_dispatch input.
+  ROCM_VERSION: ${{ vars.ROCM_VERSION }}
+  GPU_FAMILY: ${{ vars.GPU_FAMILY || 'gfx94X-dcgpu' }}
   BUILD_TYPE: Release
   # Optional Step 6 in build_packages_local.sh: set repo Actions variable
   # RBT_AUTO_DETECT_LOCAL_UPLOAD to "1" to probe localhost:8080 when UPLOAD_TARGET is unset.
-  # Leave the variable undefined for default (no probe; S3 uses workflow steps only).
   RBT_AUTO_DETECT_LOCAL_UPLOAD: ${{ vars.RBT_AUTO_DETECT_LOCAL_UPLOAD }}
 
 jobs:
   # ----------------------------------------
-  # Ubuntu 22.04: DEB & TGZ
+  # Resolve which branches to build.
+  # Non-schedule events: just the triggering branch.
+  # Schedule: default branch + any branches matching vars.ACTIVE_BRANCHES glob patterns.
+  # ----------------------------------------
+  prepare-nightly-branches:
+    name: Prepare nightly branch matrix
+    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    outputs:
+      branches_json: ${{ steps.branches.outputs.branches_json }}
+    steps:
+      - name: Resolve branch matrix
+        id: branches
+        env:
+          ACTIVE_BRANCHES: ${{ vars.ACTIVE_BRANCHES }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          import urllib.request
+
+          def list_remote_branches():
+              token = os.environ["GITHUB_TOKEN"]
+              repo = os.environ["GITHUB_REPOSITORY"]
+              names = []
+              page = 1
+              while True:
+                  url = (
+                      f"https://api.github.com/repos/{repo}/branches"
+                      f"?per_page=100&page={page}"
+                  )
+                  req = urllib.request.Request(
+                      url,
+                      headers={
+                          "Authorization": f"Bearer {token}",
+                          "Accept": "application/vnd.github+json",
+                          "User-Agent": "rbt-build-relocatable-packages",
+                      },
+                  )
+                  with urllib.request.urlopen(req) as resp:
+                      batch = json.loads(resp.read().decode())
+                  if not batch:
+                      break
+                  for item in batch:
+                      names.append(item["name"])
+                  if len(batch) < 100:
+                      break
+                  page += 1
+              return names
+
+          def branch_prefix(name: str) -> str:
+              return name.split("/", 1)[0] if "/" in name else name
+
+          def glob_match(name: str, pattern: str) -> bool:
+              regex_parts = []
+              i = 0
+              while i < len(pattern):
+                  if pattern[i : i + 2] == "**":
+                      regex_parts.append(".*")
+                      i += 2
+                  elif pattern[i] == "*":
+                      regex_parts.append("[^/]*")
+                      i += 1
+                  else:
+                      regex_parts.append(re.escape(pattern[i]))
+                      i += 1
+              return re.fullmatch("".join(regex_parts), name) is not None
+
+          def skip_upload_schedule(branch: str) -> bool:
+              return branch == "release" or branch.startswith("release/")
+
+          event = os.environ["EVENT_NAME"]
+          default = os.environ["DEFAULT_BRANCH"]
+
+          if event != "schedule":
+              if event == "pull_request":
+                  branch = os.environ.get("PR_HEAD_REF") or os.environ["REF_NAME"]
+              else:
+                  branch = os.environ["REF_NAME"]
+              branches = [{
+                  "branch": branch,
+                  "is_default": branch == default,
+                  "skip_upload": False,
+                  "branch_prefix": branch_prefix(branch),
+              }]
+          else:
+              patterns = [
+                  p.strip()
+                  for p in os.environ.get("ACTIVE_BRANCHES", "").split(",")
+                  if p.strip()
+              ]
+              remote_names = list_remote_branches()
+
+              matched = set()
+              for pattern in patterns:
+                  for name in remote_names:
+                      if glob_match(name, pattern) and name != default:
+                          matched.add(name)
+
+              branches = [{
+                  "branch": default,
+                  "is_default": True,
+                  "skip_upload": False,
+                  "branch_prefix": branch_prefix(default),
+              }]
+              for name in sorted(matched):
+                  branches.append({
+                      "branch": name,
+                      "is_default": False,
+                      "skip_upload": skip_upload_schedule(name),
+                      "branch_prefix": branch_prefix(name),
+                  })
+
+          payload = json.dumps(branches)
+          print(payload)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"branches_json={payload}\n")
+          PY
+
+  # ----------------------------------------
+  # Ubuntu 22.04: DEB & TGZ (ubuntu:22.04 container, runs as root)
   # ----------------------------------------
   build-ubuntu:
-    name: Build (Ubuntu 22.04) Packages
+    name: Build Ubuntu Packages (${{ matrix.branch }})
+    needs: prepare-nightly-branches
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
+    container:
+      image: ubuntu:22.04
+      options: --add-host=host.docker.internal:host-gateway
     strategy:
+      fail-fast: false
       matrix:
-        ubuntu_version: ['22.04']
+        include: ${{ fromJson(needs.prepare-nightly-branches.outputs.branches_json) }}
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
     outputs:
       s3_bucket_ubuntu: ${{ steps.upload-s3-ubuntu.outputs.bucket }}
       s3_paths_ubuntu: ${{ steps.upload-s3-ubuntu.outputs.paths }}
 
     steps:
-      - name: Clean workspace
+      - name: Bootstrap container (git, curl, packaging tools)
         run: |
-          sudo rm -rf "${{ github.workspace }}/build" || true
-          sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}" || true
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            curl \
+            git \
+            dpkg-dev \
+            apt-utils \
+            python3 \
+            python3-pip
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
-          fetch-depth: 0    # branch.commit version tag
+          fetch-depth: 0
 
-      - name: Set ROCm Version and GPU Family
+      - name: Set build branch context
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "ROCM_VERSION=" >> $GITHUB_ENV
-            echo "Scheduled run: build script will auto-fetch latest ROCm version"
-          elif [ -n "${{ github.event.inputs.rocm_version }}" ]; then
-            echo "ROCM_VERSION=${{ github.event.inputs.rocm_version }}" >> $GITHUB_ENV
-          fi
-          if [ -n "${{ github.event.inputs.gpu_family }}" ]; then
-            echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
-          fi
+          echo "RBT_BUILD_REF_NAME=${{ matrix.branch }}" >> "$GITHUB_ENV"
+          echo "RBT_IS_DEFAULT_BRANCH=${{ matrix.is_default }}" >> "$GITHUB_ENV"
+          echo "RBT_SKIP_UPLOAD=${{ matrix.skip_upload }}" >> "$GITHUB_ENV"
+          echo "RBT_BRANCH_PREFIX=${{ matrix.branch_prefix }}" >> "$GITHUB_ENV"
+
+      - name: Configure ROCm SDK channel and version
+        run: bash .github/scripts/configure-rocm-sdk-channel.sh
+        env:
+          INPUT_ROCM_VERSION: ${{ github.event.inputs.rocm_version }}
+          VAR_ROCM_VERSION: ${{ vars.ROCM_VERSION }}
+          INPUT_GPU_FAMILY: ${{ github.event.inputs.gpu_family }}
+          ROCM_SDK_RELEASE_URL: ${{ vars.ROCM_SDK_RELEASE_URL }}
+          ROCM_SDK_RELEASE_BASE_URL: ${{ vars.ROCM_SDK_RELEASE_BASE_URL }}
+          ROCM_SDK_NIGHTLY_BASE_URL: ${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}
+          ROCM_SDK_NIGHTLY_INDEX_URL: ${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}
+
+      - name: Configure local package upload
+        if: vars.LOCAL_PACKAGE_SERVER_URL != ''
+        run: |
+          echo "UPLOAD_TARGET=${{ vars.LOCAL_PACKAGE_SERVER_URL }}" >> "$GITHUB_ENV"
 
       - name: Build and Package RBT
         run: |
           chmod +x build_packages_local.sh
-
-          # Run build script with sudo (Ubuntu runner needs sudo for apt-get)
-          sudo -E ROCM_VERSION=${{ env.ROCM_VERSION }} \
-          GPU_FAMILY=${{ env.GPU_FAMILY }} \
-          BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          ROCM_SDK_BASE_URL=${{ vars.ROCM_SDK_BASE_URL }} \
-          ROCM_SDK_INDEX_URL=${{ vars.ROCM_SDK_INDEX_URL }} \
+          # Container runs as root; ROCM_SDK_* env vars set by configure-rocm-sdk-channel.sh
           ./build_packages_local.sh
 
-      - name: Fix file ownership
-        if: always()
+      - name: Print local package download URL
+        if: vars.LOCAL_PACKAGE_SERVER_URL != ''
         run: |
-          sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}" || true
+          REPO="${GITHUB_REPOSITORY##*/}"
+          BRANCH="${GITHUB_REF_NAME}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g')
+          DATE=$(date +%Y-%m-%d)
+          URL="${{ vars.LOCAL_PACKAGE_SERVER_URL }}/${REPO}/${SAFE_BRANCH}/${DATE}/"
+          echo "================================================================"
+          echo "  Package downloads for this build (Ubuntu)"
+          echo "  $URL"
+          echo "================================================================"
+          {
+            echo "## Package Downloads (Ubuntu)"
+            echo ""
+            echo "[$URL]($URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify DEB Package
         run: |
           cd ./build
-          DEB_FILE=$(ls amdrocm*-rocm-bandwidth-test*.deb | head -1)
+          DEB_FILE=$(ls amdrocm*-rbt*.deb 2>/dev/null | head -1)
           if [ -n "$DEB_FILE" ]; then
             echo "=== DEB Package Info ==="
             dpkg-deb -I "$DEB_FILE"
@@ -113,23 +287,13 @@ jobs:
             echo "Package filename: $DEB_FILE"
           fi
 
-      - name: Upload artifacts (always, for inspection)
-        uses: actions/upload-artifact@v4
-        with:
-          name: ubuntu-22.04-packages
-          path: |
-            build/amdrocm*-rocm-bandwidth-test*.deb
-            build/amdrocm*-rocm-bandwidth-test*.rpm
-            build/amdrocm*-rocm-bandwidth-test*.tar.gz
-          if-no-files-found: error
-
-      # S3 upload for repo ROCm/rocm_bandwidth_test (schedule, push, pull request, manual)
+      # S3 upload for ROCm/rocm_bandwidth_test only (skip fork PRs: OIDC token response is empty → JSON parse fails)
       - name: Install AWS CLI
-        if: github.repository == 'ROCm/rocm_bandwidth_test'
-        run: sudo apt-get update && sudo apt-get install -y awscli
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
+        run: apt-get update && apt-get install -y awscli
 
       - name: Configure AWS credentials
-        if: github.repository == 'ROCm/rocm_bandwidth_test'
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | python3 -c "import sys,json; print(json.load(sys.stdin)['value'])")
@@ -147,50 +311,26 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
 
-      # S3 routing: release/* → release/; default branch builds → nightly/; PRs → pr-<number>/ (no branch name in path)
       - name: Upload Ubuntu packages to S3
         id: upload-s3-ubuntu
-        if: github.repository == 'ROCm/rocm_bandwidth_test' && vars.AWS_S3_BUCKET != ''
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
+        run: sh .github/scripts/rbt-s3-upload-route.sh upload-deb
         env:
           AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
-          # PR uploads use PR number only so development branch names are not exposed in S3 keys.
-          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            S3_PATH="s3://${AWS_S3_BUCKET}/rbt/pr-${PR_NUMBER}/${GITHUB_RUN_NUMBER}/ubuntu-22.04"
-            METADATA="skip"
-          elif [[ "${GITHUB_REF_NAME}" == release/* ]]; then
-            S3_PATH="s3://${AWS_S3_BUCKET}/release/rbt/deb"
-            METADATA="generate"
-          else
-            S3_PATH="s3://${AWS_S3_BUCKET}/nightly/rbt/deb"
-            METADATA="generate"
-          fi
-          echo "S3_DEB_PATH=${S3_PATH}"      >> "$GITHUB_ENV"
-          echo "DEB_METADATA=${METADATA}"    >> "$GITHUB_ENV"
-          aws s3 cp build/ "${S3_PATH}/" --recursive --exclude "*" \
-            --include "amdrocm*-rocm-bandwidth-test*.deb" \
-            --include "amdrocm*-rocm-bandwidth-test*.tar.gz"
-          echo "Uploaded to ${S3_PATH}"
 
-      # Generate APT repo metadata (Packages, Packages.gz, Release) so the S3 path
-      # can be consumed directly as a DEB repository by apt.
-      # Only runs when the repository is ROCm/rocm_bandwidth_test and the event is schedule, push, or manual.
+      # Generate APT repo metadata (Packages, Packages.gz, Release) for release/nightly channels.
+      # dpkg-scanpackages emits "Filename: ./foo.deb". S3/CloudFront keys are literal, so
+      # that path 404s unless we strip the leading "./".
       - name: Generate and upload DEB repo metadata to S3
-        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && matrix.skip_upload != true && (github.event_name != 'schedule' || matrix.is_default == true)
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           [ -z "$BUCKET" ] && exit 0
 
-          sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils
-
-          BASE="rbt"
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
-            DEB_PREFIX="release/${BASE}/deb"
-          else
-            DEB_PREFIX="nightly/${BASE}/deb"
-          fi
+          # dpkg-dev and apt-utils were installed in the Bootstrap container step.
+          set -- $(sh .github/scripts/rbt-s3-upload-route.sh deb-repo-prefix)
+          DEB_PREFIX="$1"
+          APT_SUITE="$2"
 
           STAGING=$(mktemp -d)
 
@@ -199,29 +339,54 @@ jobs:
             --exclude "Packages*" --exclude "Release*" --exclude "InRelease" \
             --no-progress || true
 
-          cp ./build/amdrocm*-rocm-bandwidth-test*.deb "$STAGING/" 2>/dev/null || true
+          cp ./build/amdrocm*-rbt*.deb "$STAGING/" 2>/dev/null || true
 
           cd "$STAGING"
           dpkg-scanpackages --multiversion . /dev/null > Packages
+          sed -i 's#^Filename: \./#Filename: #g' Packages
           gzip -k -f Packages
-          apt-ftparchive release . > Release
+          apt-ftparchive \
+            -o APT::FTPArchive::Release::Origin="ROCm Bandwidth Test" \
+            -o APT::FTPArchive::Release::Label="${APT_SUITE}" \
+            -o APT::FTPArchive::Release::Suite="${APT_SUITE}" \
+            -o APT::FTPArchive::Release::Codename="${APT_SUITE}" \
+            release . > Release
 
           aws s3 sync "$STAGING/" "s3://${BUCKET}/${DEB_PREFIX}/" --no-progress
 
           echo "=== DEB repo metadata uploaded to s3://${BUCKET}/${DEB_PREFIX}/ ==="
-          aws s3 ls "s3://${BUCKET}/${DEB_PREFIX}/" --human-readable
+          aws s3 ls "s3://${BUCKET}/${DEB_PREFIX}/" --human-readable || true
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+
+      - name: Upload DEB Package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-22.04-deb-${{ matrix.branch_prefix }}
+          path: build/amdrocm*-rbt*.deb
+          if-no-files-found: error
+
+      - name: Upload TGZ Package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-22.04-tgz-${{ matrix.branch_prefix }}
+          path: build/amdrocm*-rbt*.tar.gz
+          if-no-files-found: warn
 
   # ----------------------------------------
-  # manylinux 2.28: RPM & TGZ
+  # manylinux 2.28: RPM & TGZ (container, runs as root)
   # ----------------------------------------
   build-centos:
-    name: Build CentOS/RHEL Packages (manylinux_2_28)
+    name: Build CentOS/RHEL Packages (${{ matrix.branch }})
+    needs: prepare-nightly-branches
     runs-on: ${{ vars.RUNNER_LABEL_CONTAINER || 'ubuntu-latest' }}
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64
+      options: --add-host=host.docker.internal:host-gateway
     strategy:
+      fail-fast: false
       matrix:
-        distro: ['manylinux_2_28']
+        include: ${{ fromJson(needs.prepare-nightly-branches.outputs.branches_json) }}
     outputs:
       s3_bucket_centos: ${{ steps.upload-s3-centos.outputs.bucket }}
       s3_paths_centos: ${{ steps.upload-s3-centos.outputs.paths }}
@@ -234,36 +399,60 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set ROCm Version and GPU Family
+      - name: Set build branch context
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "ROCM_VERSION=" >> $GITHUB_ENV
-            echo "Scheduled run: build script will auto-fetch latest ROCm version"
-          elif [ -n "${{ github.event.inputs.rocm_version }}" ]; then
-            echo "ROCM_VERSION=${{ github.event.inputs.rocm_version }}" >> $GITHUB_ENV
-          fi
-          if [ -n "${{ github.event.inputs.gpu_family }}" ]; then
-            echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
-          fi
+          echo "RBT_BUILD_REF_NAME=${{ matrix.branch }}" >> "$GITHUB_ENV"
+          echo "RBT_IS_DEFAULT_BRANCH=${{ matrix.is_default }}" >> "$GITHUB_ENV"
+          echo "RBT_SKIP_UPLOAD=${{ matrix.skip_upload }}" >> "$GITHUB_ENV"
+          echo "RBT_BRANCH_PREFIX=${{ matrix.branch_prefix }}" >> "$GITHUB_ENV"
+
+      - name: Configure ROCm SDK channel and version
+        run: bash .github/scripts/configure-rocm-sdk-channel.sh
+        env:
+          INPUT_ROCM_VERSION: ${{ github.event.inputs.rocm_version }}
+          VAR_ROCM_VERSION: ${{ vars.ROCM_VERSION }}
+          INPUT_GPU_FAMILY: ${{ github.event.inputs.gpu_family }}
+          ROCM_SDK_RELEASE_URL: ${{ vars.ROCM_SDK_RELEASE_URL }}
+          ROCM_SDK_RELEASE_BASE_URL: ${{ vars.ROCM_SDK_RELEASE_BASE_URL }}
+          ROCM_SDK_NIGHTLY_BASE_URL: ${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}
+          ROCM_SDK_NIGHTLY_INDEX_URL: ${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}
+
+      - name: Configure local package upload
+        if: vars.LOCAL_PACKAGE_SERVER_URL != ''
+        run: |
+          echo "UPLOAD_TARGET=${{ vars.LOCAL_PACKAGE_SERVER_URL }}" >> "$GITHUB_ENV"
 
       - name: Build and Package RBT
         run: |
           chmod +x build_packages_local.sh
-
-          ROCM_VERSION=${{ env.ROCM_VERSION }} \
-          GPU_FAMILY=${{ env.GPU_FAMILY }} \
-          BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          ROCM_SDK_BASE_URL=${{ vars.ROCM_SDK_BASE_URL }} \
-          ROCM_SDK_INDEX_URL=${{ vars.ROCM_SDK_INDEX_URL }} \
           ./build_packages_local.sh
+
+      - name: Print local package download URL
+        if: vars.LOCAL_PACKAGE_SERVER_URL != ''
+        run: |
+          REPO="${GITHUB_REPOSITORY##*/}"
+          BRANCH="${GITHUB_REF_NAME}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g')
+          DATE=$(date +%Y-%m-%d)
+          URL="${{ vars.LOCAL_PACKAGE_SERVER_URL }}/${REPO}/${SAFE_BRANCH}/${DATE}/"
+          echo "================================================================"
+          echo "  Package downloads for this build (CentOS/RHEL)"
+          echo "  $URL"
+          echo "================================================================"
+          {
+            echo "## Package Downloads (CentOS/RHEL)"
+            echo ""
+            echo "[$URL]($URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify RPM Package
         run: |
           cd ./build
-          RPM_FILE=$(ls amdrocm*-rocm-bandwidth-test*.rpm | head -1)
+          RPM_FILE=$(ls amdrocm*-rbt*.rpm 2>/dev/null | head -1)
           if [ -n "$RPM_FILE" ]; then
             echo "=== RPM Package Info ==="
             rpm -qip "$RPM_FILE"
@@ -277,23 +466,14 @@ jobs:
             echo "Package filename: $RPM_FILE"
           fi
 
-      - name: Upload artifacts (always, for inspection)
-        uses: actions/upload-artifact@v4
-        with:
-          name: centos-packages
-          path: |
-            build/amdrocm*-rocm-bandwidth-test*.rpm
-            build/amdrocm*-rocm-bandwidth-test*.tar.gz
-          if-no-files-found: error
-
-      # S3 upload for repo ROCm/rocm_bandwidth_test (schedule, push, pull request, manual)
+      # S3 upload for ROCm/rocm_bandwidth_test only (skip fork PRs — OIDC not usable)
       - name: Install AWS CLI
-        if: github.repository == 'ROCm/rocm_bandwidth_test'
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           python3 -m pip install --break-system-packages awscli || (yum install -y python3-pip && pip3 install awscli)
 
       - name: Configure AWS credentials
-        if: github.repository == 'ROCm/rocm_bandwidth_test'
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | python3 -c "import sys,json; print(json.load(sys.stdin)['value'])")
@@ -311,55 +491,24 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
 
-      # S3 routing: release/* → release/; default branch builds → nightly/; PRs → pr-<number>/ (no branch name in path)
       - name: Upload CentOS/RHEL packages to S3
         id: upload-s3-centos
-        if: github.repository == 'ROCm/rocm_bandwidth_test' && vars.AWS_S3_BUCKET != ''
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
+        run: sh .github/scripts/rbt-s3-upload-route.sh upload-rpm-tar
         env:
           AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
-          # PR uploads use PR number only so development branch names are not exposed in S3 keys.
-          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
-          DISTRO_SEGMENT: ${{ matrix.distro }}
-        run: |
-          set -euo pipefail
-          BASE="rbt"
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            S3_PATH="s3://${AWS_S3_BUCKET}/${BASE}/pr-${PR_NUMBER}/${GITHUB_RUN_NUMBER}/${DISTRO_SEGMENT}"
-          elif [[ "${GITHUB_REF_NAME}" == release/* ]]; then
-            S3_PATH="s3://${AWS_S3_BUCKET}/release/${BASE}/rpm"
-          else
-            S3_PATH="s3://${AWS_S3_BUCKET}/nightly/${BASE}/rpm"
-          fi
-          aws s3 cp build/ "${S3_PATH}/" --recursive --exclude "*" \
-            --include "amdrocm*-rocm-bandwidth-test*.rpm" \
-            --include "amdrocm*-rocm-bandwidth-test*.tar.gz"
-          echo "Uploaded to ${S3_PATH}"
-          echo "bucket=${AWS_S3_BUCKET}" >> "$GITHUB_OUTPUT"
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            echo "paths=CentOS/RHEL packages|${BASE}/pr-${PR_NUMBER}/${GITHUB_RUN_NUMBER}/${DISTRO_SEGMENT}" >> "$GITHUB_OUTPUT"
-          elif [[ "${GITHUB_REF_NAME}" == release/* ]]; then
-            echo "paths=CentOS/RHEL RPM & TGZ|release/${BASE}/rpm" >> "$GITHUB_OUTPUT"
-          else
-            echo "paths=CentOS/RHEL RPM & TGZ|nightly/${BASE}/rpm" >> "$GITHUB_OUTPUT"
-          fi
 
       # Generate YUM/DNF repo metadata (repodata/) so the S3 path can be consumed
       # directly as an RPM repository by yum/dnf.
-      # Only runs when the repository is ROCm/rocm_bandwidth_test and the event is schedule, push, or manual.
       - name: Generate and upload RPM repodata to S3
-        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.repository == 'ROCm/rocm_bandwidth_test' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && matrix.skip_upload != true && (github.event_name != 'schedule' || matrix.is_default == true)
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           [ -z "$BUCKET" ] && exit 0
 
           yum install -y createrepo_c || yum install -y createrepo
 
-          BASE="rbt"
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
-            RPM_PREFIX="release/${BASE}/rpm"
-          else
-            RPM_PREFIX="nightly/${BASE}/rpm"
-          fi
+          RPM_PREFIX=$(sh .github/scripts/rbt-s3-upload-route.sh rpm-repo-prefix)
 
           STAGING=$(mktemp -d)
 
@@ -367,21 +516,40 @@ jobs:
           aws s3 sync "s3://${BUCKET}/${RPM_PREFIX}/" "$STAGING/" \
             --exclude "repodata/*" --no-progress || true
 
-          cp ./build/amdrocm*-rocm-bandwidth-test*.rpm "$STAGING/" 2>/dev/null || true
+          cp ./build/amdrocm*-rbt*.rpm "$STAGING/" 2>/dev/null || true
 
           createrepo_c "$STAGING" || createrepo "$STAGING"
 
           aws s3 sync "$STAGING/" "s3://${BUCKET}/${RPM_PREFIX}/" --no-progress
 
           echo "=== RPM repodata uploaded to s3://${BUCKET}/${RPM_PREFIX}/repodata/ ==="
-          aws s3 ls "s3://${BUCKET}/${RPM_PREFIX}/repodata/" --human-readable
+          aws s3 ls "s3://${BUCKET}/${RPM_PREFIX}/repodata/" --human-readable || true
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
 
+      - name: Upload RPM Package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: centos-rpm-${{ matrix.branch_prefix }}
+          path: build/amdrocm*-rbt*.rpm
+          if-no-files-found: error
+
+      - name: Upload TGZ Package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: centos-tgz-${{ matrix.branch_prefix }}
+          path: build/amdrocm*-rbt*.tar.gz
+          if-no-files-found: error
+
+  # ----------------------------------------
+  # Collect S3 links and summarize the build.
+  # Skipped on schedule: matrix output aggregation is unreliable across dynamic matrices.
+  # ----------------------------------------
   create-release:
     name: Create Release Summary
     needs: [build-ubuntu, build-centos]
     runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
-    # Only runs when the workflow is not cancelled and always() is true
-    if: always() && !cancelled()
+    if: always() && !cancelled() && github.event_name != 'schedule'
 
     steps:
       - name: Generate Build Report
@@ -398,26 +566,26 @@ jobs:
 
           ### Ubuntu/Debian
           ```bash
-          sudo dpkg -i amdrocm*-rocm-bandwidth-test_*.deb
+          sudo dpkg -i amdrocm*-rbt_*.deb
           ```
 
           ### CentOS/RHEL
           ```bash
-          sudo rpm -i --replacefiles --nodeps amdrocm*-rocm-bandwidth-test-*.rpm
+          sudo rpm -i --replacefiles --nodeps amdrocm*-rbt-*.rpm
           ```
 
           ### Relocatable TGZ (Any Linux Distribution)
           ```bash
-          tar -xzf amdrocm*-rocm-bandwidth-test-*.tar.gz -C /opt/rocm/
-          export PATH=/opt/rocm/rbt/bin:$PATH
-          export LD_LIBRARY_PATH=/opt/rocm/rbt/lib:$LD_LIBRARY_PATH
+          sudo mkdir -p /opt/rocm/extras-<major>
+          sudo tar -xzf amdrocm*-rbt-*.tar.gz -C /opt/rocm/extras-<major>
+          export PATH=/opt/rocm/extras-<major>/bin:$PATH
+          export LD_LIBRARY_PATH=/opt/rocm/extras-<major>/lib:$LD_LIBRARY_PATH
           ```
 
           ## Notes
           - All packages are built with relocatable RPATH settings
           - TGZ packages can be extracted to any location
-          - Install path: /opt/rocm/rbt
-          - ROCm SDK from TheRock nightly builds is used
+          - Install path: /opt/rocm/extras-<rocm_major>
           REPORT
 
       - name: Add S3 upload links to build report

--- a/.github/workflows/rbt-nightly-tests.yml
+++ b/.github/workflows/rbt-nightly-tests.yml
@@ -1,0 +1,334 @@
+name: RBT Nightly Tests
+
+# Picks up the latest RBT tarball published at the index URL configured in
+# vars.RBT_TARBALL_INDEX_URL, copies it to a configurable target node, installs
+# it there, runs bandwidth tests on that node, and uploads a Markdown report + logs.
+#
+# Orchestration lives in this workflow; install/test/report steps run via
+# rbt_nightly_test.sh (same pattern as build-relocatable-packages.yml +
+# build_packages_local.sh).
+#
+# Required repo configuration: see .github/workflows/README_NIGHTLY_TESTS.md
+
+# Triggers
+# --------
+# - schedule: daily poll of vars.RBT_TARBALL_INDEX_URL
+# - workflow_run: after Build Relocatable Packages completes successfully
+# - workflow_dispatch: manual run with optional overrides
+
+on:
+  schedule:
+    - cron: '0 15 * * *'
+  workflow_run:
+    workflows: ["Build Relocatable Packages"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      tarball_url:
+        description: 'Override tarball URL (default: latest from vars.RBT_TARBALL_INDEX_URL)'
+        required: false
+        default: ''
+      target_node:
+        description: 'Hostname/IP of node to install RBT on and run tests (default: secrets.RBT_TARGET_NODE)'
+        required: false
+        default: ''
+      target_user:
+        description: 'SSH user on the target node (default: secrets.RBT_TARGET_USER)'
+        required: false
+        default: ''
+      remote_work_dir:
+        description: 'Working dir on the target node (default: vars.RBT_REMOTE_WORK_DIR or /tmp/rbt-nightly-<run_id>)'
+        required: false
+        default: ''
+      target_rocm_path:
+        description: 'ROCm tarball install root on the target node (default: vars.RBT_TARGET_ROCM_PATH)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rbt-nightly-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  TARBALL_INDEX_URL: ${{ vars.RBT_TARBALL_INDEX_URL }}
+
+jobs:
+  detect-tarball:
+    name: Detect latest RBT tarball
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    outputs:
+      tarball_url:  ${{ steps.resolve.outputs.tarball_url }}
+      tarball_name: ${{ steps.resolve.outputs.tarball_name }}
+    steps:
+      - name: Restore last-seen marker (cron path)
+        if: github.event_name == 'schedule'
+        uses: actions/cache@v4
+        with:
+          path: last_tarball_marker.txt
+          key: rbt-nightly-tarball-${{ github.run_id }}
+          restore-keys: |
+            rbt-nightly-tarball-
+
+      - name: Resolve latest tarball URL
+        id: resolve
+        env:
+          INDEX_URL: ${{ env.TARBALL_INDEX_URL }}
+          INPUT_URL: ${{ inputs.tarball_url }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${INPUT_URL:-}" ] && [ -z "${INDEX_URL:-}" ]; then
+            echo "::error::vars.RBT_TARBALL_INDEX_URL is not set; set it or pass workflow_dispatch.tarball_url"
+            exit 1
+          fi
+
+          fetch_latest() {
+            local idx="$1"
+            local html
+            html="$(curl -sL --max-time 30 "$idx" || true)"
+            echo "$html" \
+              | grep -oE 'amdrocm[0-9]*-rbt-[0-9A-Za-z._\-]+-Linux\.tar\.gz' \
+              | sort -uV \
+              | tail -n 1 \
+              | awk -v p="${idx%/}" '{print p "/" $0}'
+          }
+
+          if [ -n "${INPUT_URL:-}" ]; then
+            URL="$INPUT_URL"
+          else
+            URL="$(fetch_latest "$INDEX_URL")"
+          fi
+
+          if [ -z "${URL:-}" ]; then
+            echo "::error::Could not resolve a tarball URL from $INDEX_URL"
+            exit 1
+          fi
+
+          NAME="$(basename "$URL")"
+
+          if [ "$EVENT_NAME" = "schedule" ] && [ -f last_tarball_marker.txt ]; then
+            LAST="$(cat last_tarball_marker.txt)"
+            if [ "$LAST" = "$NAME" ]; then
+              echo "::notice::Latest tarball ($NAME) unchanged since last scheduled run — running tests anyway."
+            else
+              echo "::notice::New tarball (previous: $LAST, now: $NAME)."
+            fi
+          fi
+          echo "$NAME" > last_tarball_marker.txt
+
+          {
+            echo "tarball_url=$URL"
+            echo "tarball_name=$NAME"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Latest tarball : $NAME"
+          echo "URL            : $URL"
+
+      - name: Save marker (cron path)
+        if: github.event_name == 'schedule'
+        uses: actions/cache/save@v4
+        with:
+          path: last_tarball_marker.txt
+          key: rbt-nightly-tarball-${{ steps.resolve.outputs.tarball_name }}
+
+  prepare-test-context:
+    name: Prepare test run context
+    needs: detect-tarball
+    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    outputs:
+      remote_work_dir: ${{ steps.prepare.outputs.remote_work_dir }}
+      rocm_major:      ${{ steps.prepare.outputs.rocm_major }}
+      install_dir:     ${{ steps.prepare.outputs.install_dir }}
+      rbt_bin:         ${{ steps.prepare.outputs.rbt_bin }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Validate configuration and derive paths
+        id: prepare
+        env:
+          TARBALL_NAME:          ${{ needs.detect-tarball.outputs.tarball_name }}
+          TARGET_NODE:           ${{ inputs.target_node || secrets.RBT_TARGET_NODE }}
+          TARGET_ROCM_PATH:      ${{ inputs.target_rocm_path || vars.RBT_TARGET_ROCM_PATH }}
+          INPUT_REMOTE_WORK_DIR: ${{ inputs.remote_work_dir }}
+          VAR_REMOTE_WORK_DIR:   ${{ vars.RBT_REMOTE_WORK_DIR }}
+          GITHUB_RUN_ID:         ${{ github.run_id }}
+        run: |
+          chmod +x rbt_nightly_test.sh
+          ./rbt_nightly_test.sh validate-config
+
+  install-rbt-on-target:
+    name: Install RBT on target node
+    needs: [detect-tarball, prepare-test-context]
+    runs-on: ${{ vars.RBT_TEST_RUNNER_LABEL || 'self-hosted' }}
+    timeout-minutes: 120
+    env:
+      TARBALL_URL:      ${{ needs.detect-tarball.outputs.tarball_url }}
+      TARBALL_NAME:     ${{ needs.detect-tarball.outputs.tarball_name }}
+      TARGET_NODE:      ${{ inputs.target_node || secrets.RBT_TARGET_NODE }}
+      TARGET_USER:      ${{ inputs.target_user || secrets.RBT_TARGET_USER }}
+      TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RBT_TARGET_ROCM_PATH }}
+      REMOTE_WORK_DIR:  ${{ needs.prepare-test-context.outputs.remote_work_dir }}
+      ROCM_MAJOR:       ${{ needs.prepare-test-context.outputs.rocm_major }}
+      INSTALL_DIR:      ${{ needs.prepare-test-context.outputs.install_dir }}
+      RBT_BIN:          ${{ needs.prepare-test-context.outputs.rbt_bin }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH for target node
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.RBT_TARGET_SSH_KEY }}
+        run: |
+          chmod +x rbt_nightly_test.sh
+          ./rbt_nightly_test.sh setup-ssh
+
+      - name: Verify ROCm prerequisites on target node
+        run: ./rbt_nightly_test.sh verify-rocm
+
+      - name: Download tarball on runner
+        run: ./rbt_nightly_test.sh download-tarball
+
+      - name: Copy tarball to target node
+        run: ./rbt_nightly_test.sh copy-to-target
+
+      - name: Install RBT on target node
+        run: ./rbt_nightly_test.sh install-rbt
+
+      - name: Verify RBT binary library resolution on target node
+        run: ./rbt_nightly_test.sh verify-rbt-binary
+
+      - name: Cleanup local SSH state
+        if: always()
+        run: ./rbt_nightly_test.sh cleanup-local-ssh
+
+  run-rbt-tests:
+    name: Run RBT bandwidth tests on target node
+    needs: [detect-tarball, prepare-test-context, install-rbt-on-target]
+    runs-on: ${{ vars.RBT_TEST_RUNNER_LABEL || 'self-hosted' }}
+    timeout-minutes: 180
+    outputs:
+      rc_healthcheck:      ${{ steps.tests.outputs.rc_healthcheck }}
+      start_healthcheck:   ${{ steps.tests.outputs.start_healthcheck }}
+      end_healthcheck:     ${{ steps.tests.outputs.end_healthcheck }}
+      rc_p2p:              ${{ steps.tests.outputs.rc_p2p }}
+      start_p2p:           ${{ steps.tests.outputs.start_p2p }}
+      end_p2p:             ${{ steps.tests.outputs.end_p2p }}
+      rc_topology:         ${{ steps.tests.outputs.rc_topology }}
+      start_topology:      ${{ steps.tests.outputs.start_topology }}
+      end_topology:        ${{ steps.tests.outputs.end_topology }}
+      rbt_version:         ${{ steps.versions.outputs.rbt_version }}
+      target_rocm_version: ${{ steps.versions.outputs.target_rocm_version }}
+    env:
+      TARBALL_URL:      ${{ needs.detect-tarball.outputs.tarball_url }}
+      TARBALL_NAME:     ${{ needs.detect-tarball.outputs.tarball_name }}
+      TARGET_NODE:      ${{ inputs.target_node || secrets.RBT_TARGET_NODE }}
+      TARGET_USER:      ${{ inputs.target_user || secrets.RBT_TARGET_USER }}
+      TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RBT_TARGET_ROCM_PATH }}
+      REMOTE_WORK_DIR:  ${{ needs.prepare-test-context.outputs.remote_work_dir }}
+      ROCM_MAJOR:       ${{ needs.prepare-test-context.outputs.rocm_major }}
+      INSTALL_DIR:      ${{ needs.prepare-test-context.outputs.install_dir }}
+      RBT_BIN:          ${{ needs.prepare-test-context.outputs.rbt_bin }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH for target node
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.RBT_TARGET_SSH_KEY }}
+        run: |
+          chmod +x rbt_nightly_test.sh
+          ./rbt_nightly_test.sh setup-ssh
+
+      - name: Run RBT bandwidth tests on target node
+        id: tests
+        run: ./rbt_nightly_test.sh run-tests
+
+      - name: Collect logs from target node
+        if: always()
+        run: ./rbt_nightly_test.sh collect-logs
+
+      - name: Capture RBT and ROCm versions from target
+        id: versions
+        if: always()
+        run: ./rbt_nightly_test.sh capture-versions
+
+      - name: Upload test logs (intermediate)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbt-nightly-logs-${{ github.run_id }}
+          path: ./reports/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Cleanup remote work dir and local SSH state
+        if: always()
+        run: |
+          ./rbt_nightly_test.sh cleanup-remote
+          ./rbt_nightly_test.sh cleanup-local-ssh
+
+  create-test-report:
+    name: Create Test Report
+    needs: [detect-tarball, prepare-test-context, run-rbt-tests]
+    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    if: always() && !cancelled() && needs.detect-tarball.result == 'success' && needs.run-rbt-tests.result != 'skipped'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download test logs
+        uses: actions/download-artifact@v4
+        with:
+          name: rbt-nightly-logs-${{ github.run_id }}
+          path: ./reports
+        continue-on-error: true
+
+      - name: Build test report
+        id: report
+        env:
+          TARBALL_URL:           ${{ needs.detect-tarball.outputs.tarball_url }}
+          TARBALL_NAME:          ${{ needs.detect-tarball.outputs.tarball_name }}
+          TARGET_ROCM_PATH:      ${{ inputs.target_rocm_path || vars.RBT_TARGET_ROCM_PATH }}
+          REMOTE_WORK_DIR:       ${{ needs.prepare-test-context.outputs.remote_work_dir }}
+          RBT_BIN:               ${{ needs.prepare-test-context.outputs.rbt_bin }}
+          RBT_HEALTHCHECK_RC:    ${{ needs.run-rbt-tests.outputs.rc_healthcheck }}
+          RBT_HEALTHCHECK_START: ${{ needs.run-rbt-tests.outputs.start_healthcheck }}
+          RBT_HEALTHCHECK_END:   ${{ needs.run-rbt-tests.outputs.end_healthcheck }}
+          RBT_P2P_RC:            ${{ needs.run-rbt-tests.outputs.rc_p2p }}
+          RBT_P2P_START:         ${{ needs.run-rbt-tests.outputs.start_p2p }}
+          RBT_P2P_END:           ${{ needs.run-rbt-tests.outputs.end_p2p }}
+          RBT_TOPOLOGY_RC:       ${{ needs.run-rbt-tests.outputs.rc_topology }}
+          RBT_TOPOLOGY_START:    ${{ needs.run-rbt-tests.outputs.start_topology }}
+          RBT_TOPOLOGY_END:      ${{ needs.run-rbt-tests.outputs.end_topology }}
+          RBT_VERSION:           ${{ needs.run-rbt-tests.outputs.rbt_version }}
+          TARGET_ROCM_VERSION:   ${{ needs.run-rbt-tests.outputs.target_rocm_version }}
+          GITHUB_RUN_ID:         ${{ github.run_id }}
+          GITHUB_SERVER_URL:     ${{ github.server_url }}
+          GITHUB_REPOSITORY:     ${{ github.repository }}
+          GITHUB_EVENT_NAME:     ${{ github.event_name }}
+        run: |
+          chmod +x rbt_nightly_test.sh
+          mkdir -p ./reports
+          ./rbt_nightly_test.sh build-report
+
+      - name: Upload report and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbt-nightly-report-${{ github.run_id }}
+          path: ./reports/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Fail the workflow if any test failed
+        if: steps.report.outputs.overall == 'FAIL' || needs.run-rbt-tests.result == 'failure'
+        run: |
+          echo "::error::RBT test failure — healthcheck rc=${{ needs.run-rbt-tests.outputs.rc_healthcheck }}, p2p rc=${{ needs.run-rbt-tests.outputs.rc_p2p }}, topology rc=${{ needs.run-rbt-tests.outputs.rc_topology }}"
+          exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,9 @@ else()
 endif()
 set(AMD_PROJECT_VERSION_FULL "${AMD_PROJECT_VERSION_MAJOR}.${AMD_PROJECT_VERSION_MINOR}.${AMD_PROJECT_VERSION_PATCH}")
 
+# ROCm major version for package naming and install paths (per RFC0012)
+set(ROCM_MAJOR_VERSION "0" CACHE STRING "ROCm major version (e.g. 7 for ROCm 7.x)")
+
 #
 project(${AMD_TARGET_NAME}
     VERSION ${AMD_TARGET_VERSION_TEXT}

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -7,7 +7,7 @@
 set -e  # Exit on error
 
 # Configuration
-##GPU_FAMILY="${GPU_FAMILY:-gfx110X-all}"
+ROCM_VERSION="${ROCM_VERSION:-}"            # empty => auto-fetch latest
 GPU_FAMILY="${GPU_FAMILY:-gfx94X-dcgpu}"
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 
@@ -15,9 +15,74 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${REPO_ROOT}/build"
 ROCM_INSTALL_DIR="$REPO_ROOT/rocm-sdk"
 ROCM_BANDWIDTH_TEST_ROOT="${REPO_ROOT}"
+ROCM_BANDWIDTH_TEST_PKG_PREFIX="rocm-bandwidth-test"
 
+###
+# SDK Source Configuration (nightly / release / auto channels)
+# Override via environment variables or GitHub Actions repository variables (vars.*).
+#
+# ROCM_SDK_CHANNEL:
+#   "nightly"  - always fetch from the nightly index
+#   "release"  - always fetch the latest X.Y.Z release tarball
+#   "auto"     - (default) infer from ROCM_VERSION format if supplied,
+#                else fall back to nightly
+#
+# In CI the "Configure ROCm SDK channel" workflow step sets these before
+# calling this script.  Locally, set ROCM_SDK_CHANNEL (or the URL vars
+# directly) in your environment before running the script.
+###
+_ROCM_NIGHTLY_INDEX_DEFAULT="https://therock-nightly-tarball.s3.amazonaws.com/index.html"
+_ROCM_NIGHTLY_BASE_DEFAULT="https://therock-nightly-tarball.s3.us-east-2.amazonaws.com"
+_ROCM_RELEASE_LIST_DEFAULT="https://repo.amd.com/rocm/tarball/"
+_ROCM_RELEASE_BASE_DEFAULT="https://repo.amd.com/rocm/tarball"
 
+ROCM_SDK_CHANNEL="${ROCM_SDK_CHANNEL:-auto}"
+ROCM_SDK_RELEASE_URL="${ROCM_SDK_RELEASE_URL:-}"
+
+if [ "$ROCM_SDK_CHANNEL" = "nightly" ]; then
+    ROCM_SDK_RELEASE_URL=""
+    ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_NIGHTLY_INDEX_URL:-${ROCM_SDK_INDEX_URL:-$_ROCM_NIGHTLY_INDEX_DEFAULT}}"
+elif [ "$ROCM_SDK_CHANNEL" = "release" ]; then
+    ROCM_SDK_RELEASE_URL="${ROCM_SDK_RELEASE_URL:-$_ROCM_RELEASE_LIST_DEFAULT}"
+    if [ -z "${ROCM_SDK_BASE_URL:-}" ]; then
+        if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
+            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
+        else
+            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/}"
+        fi
+    fi
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_INDEX_URL:-}"
+else
+    ##
+    # auto
+    if [ -n "${ROCM_SDK_RELEASE_URL}" ]; then
+        if [ -z "${ROCM_SDK_BASE_URL:-}" ]; then
+            if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
+                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
+            else
+                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/}"
+            fi
+        fi
+    else
+        ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+    fi
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_NIGHTLY_INDEX_URL:-${ROCM_SDK_INDEX_URL:-$_ROCM_NIGHTLY_INDEX_DEFAULT}}"
+fi
+
+##
+# Post-build upload configuration (optional)
+if [ -z "${UPLOAD_TARGET:-}" ] && [ -n "${RBT_AUTO_DETECT_LOCAL_UPLOAD:-}" ]; then
+    if curl -s -o /dev/null -w '' http://localhost:8080/ 2>/dev/null; then
+        UPLOAD_TARGET="http://localhost:8080"
+    fi
+fi
+UPLOAD_TARGET="${UPLOAD_TARGET:-}"
+UPLOAD_REPO="${UPLOAD_REPO:-}"
+
+###
 # Colors for output
+###
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -40,24 +105,40 @@ print_error() {
     echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
-# Function to fetch latest ROCm version for specified GPU family
-# Sets the global ROCM_VERSION variable directly
+join_base_and_file() {
+    local base="$1"
+    local path="$2"
+    base="${base%/}"
+    printf '%s/%s' "$base" "$path"
+}
+
+apply_sdk_tarball_base_for_version() {
+    local v="$1"
+    if echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+a[0-9]+'; then
+        ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+        print_info "Version matches ROCm nightly format (x.y.za…) → tarball base: $ROCM_SDK_BASE_URL"
+    elif echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_RELEASE_BASE_DEFAULT}}"
+        print_info "Version matches ROCm release format (X.Y.Z) → tarball base: $ROCM_SDK_BASE_URL"
+    fi
+}
+
+##
+# Fetch latest nightly ROCm version for the specified GPU family.
+# Sets the global ROCM_VERSION variable.
 fetch_latest_rocm_version() {
     local gpu_family="$1"
-    local index_url="https://therock-nightly-tarball.s3.amazonaws.com/index.html"
 
-    print_info "Fetching latest ROCm version for $gpu_family from TheRock..."
+    print_info "Fetching latest ROCm version for $gpu_family..."
+    print_info "Index URL: $ROCM_SDK_INDEX_URL"
 
-    # Download index page and parse for latest tarball matching GPU family
-    # Pattern: therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz
-    local latest_version=$(wget -qO- "$index_url" 2>/dev/null | \
+    local latest_version
+    latest_version=$(wget -qO- "$ROCM_SDK_INDEX_URL" 2>/dev/null | \
         grep -oP "therock-dist-linux-${gpu_family}-\K[^<\"]+(?=\.tar\.gz)" | \
         sort -V | tail -1)
 
     if [ -z "$latest_version" ]; then
-        print_error "Could not fetch latest ROCm version for $gpu_family"
-        print_info "Falling back to default version: 7.11.0a20260121"
-        ROCM_VERSION="7.11.0a20260121"
+        print_error "Could not fetch latest ROCm nightly version for $gpu_family from $ROCM_SDK_INDEX_URL"
         return 1
     fi
 
@@ -66,11 +147,101 @@ fetch_latest_rocm_version() {
     return 0
 }
 
-# Function to check and install dependencies
+##
+# Fetch latest release X.Y.Z ROCm version for the specified GPU family.
+# Sets the global ROCM_VERSION variable.
+fetch_latest_rocm_release_version() {
+    local gpu_family="$1"
+    local list_url="${ROCM_SDK_RELEASE_URL:-$_ROCM_RELEASE_LIST_DEFAULT}"
+
+    print_info "Fetching latest ROCm release version (X.Y.Z) for $gpu_family..."
+    print_info "Release listing URL: $list_url"
+
+    local latest_version
+    latest_version=$(wget -qO- "$list_url" 2>/dev/null | \
+        grep -oP "therock-dist-linux-${gpu_family}-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.tar\.gz)" | \
+        sort -V | uniq | tail -1)
+
+    if [ -z "$latest_version" ]; then
+        print_error "No therock-dist-linux-${gpu_family}-X.Y.Z.tar.gz found under release listing"
+        return 1
+    fi
+
+    print_success "Found latest ROCm release version: $latest_version"
+    ROCM_VERSION="$latest_version"
+    return 0
+}
+
+ensure_recent_cmake_ubuntu() {
+    [ -f /etc/os-release ] || return 0
+    . /etc/os-release
+    case "${ID:-}" in
+        ubuntu|debian) ;;
+        *) return 0 ;;
+    esac
+    command -v apt-get >/dev/null 2>&1 || return 0
+
+    local need_major=3 need_minor=25
+    local cur_major=0 cur_minor=0 v=""
+    if command -v cmake >/dev/null 2>&1; then
+        v="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}')"
+        cur_major="${v%%.*}"
+        local _rest="${v#*.}"
+        cur_minor="${_rest%%.*}"
+        cur_major="${cur_major:-0}"
+        cur_minor="${cur_minor:-0}"
+        if { [ "$cur_major" -gt "$need_major" ] 2>/dev/null; } \
+           || { [ "$cur_major" -eq "$need_major" ] 2>/dev/null && [ "$cur_minor" -ge "$need_minor" ] 2>/dev/null; }; then
+            print_success "cmake $v is recent enough (>= ${need_major}.${need_minor})"
+            return 0
+        fi
+        print_info "cmake $v is older than ${need_major}.${need_minor}; upgrading"
+    else
+        print_info "cmake not installed; installing recent version (>= ${need_major}.${need_minor})"
+    fi
+
+    if [ -n "${VERSION_CODENAME:-}" ] && [ "${RBT_SKIP_KITWARE_REPO:-}" != "1" ]; then
+        print_info "Trying Kitware APT repo for cmake (codename: ${VERSION_CODENAME})..."
+        apt-get install -y --no-install-recommends ca-certificates gnupg wget >/dev/null 2>&1 || true
+        if wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+            | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg 2>/dev/null \
+            && [ -s /usr/share/keyrings/kitware-archive-keyring.gpg ]; then
+            echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${VERSION_CODENAME} main" \
+                > /etc/apt/sources.list.d/kitware.list
+            if apt-get update >/dev/null 2>&1 && apt-get install -y --no-install-recommends cmake; then
+                hash -r
+                local v_new
+                v_new="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}')"
+                print_success "Installed cmake $v_new from Kitware APT repo"
+                return 0
+            fi
+            print_warning "Kitware APT install failed; falling back to pip"
+        else
+            print_warning "Could not reach apt.kitware.com; falling back to pip"
+        fi
+    fi
+
+    if ! command -v pip3 >/dev/null 2>&1; then
+        apt-get install -y --no-install-recommends python3-pip >/dev/null 2>&1 || true
+    fi
+    if command -v pip3 >/dev/null 2>&1; then
+        if pip3 install --break-system-packages --upgrade cmake 2>/dev/null \
+           || pip3 install --upgrade cmake; then
+            hash -r
+            local v_new
+            v_new="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}')"
+            print_success "Installed cmake $v_new via pip"
+            return 0
+        fi
+    fi
+
+    print_error "Could not install cmake >= ${need_major}.${need_minor}"
+    return 1
+}
+
 check_and_install_dependencies() {
     print_info "Checking for required build dependencies..."
 
-    # Detect OS
     if [ -f /etc/os-release ]; then
         . /etc/os-release
         OS=$ID
@@ -79,20 +250,6 @@ check_and_install_dependencies() {
         exit 1
     fi
 
-    case "${OS_ID}:${OS_LIKE}" in
-        ubuntu:*|debian:*|*:*debian*)   DISTRO="ubuntu" ;;
-        almalinux:*|rocky:*|rhel:*|centos:*|*:*rhel*|*:*fedora*) DISTRO="almalinux" ;;
-        *)
-            if command -v apt-get >/dev/null 2>&1; then DISTRO="ubuntu"
-            elif command -v yum >/dev/null 2>&1 || command -v dnf >/dev/null 2>&1; then DISTRO="almalinux"
-            else err "Unsupported distro: ${OS_ID}"; exit 1
-            fi
-            ;;
-    esac
-    print_info "Detected distro: ${DISTRO} (${OS_ID})"
-
-
-    # Check for command-line tools
     MISSING_TOOLS=()
     command -v cmake >/dev/null 2>&1 || MISSING_TOOLS+=("cmake")
     command -v make >/dev/null 2>&1 || MISSING_TOOLS+=("make")
@@ -104,22 +261,20 @@ check_and_install_dependencies() {
     command -v doxygen >/dev/null 2>&1 || MISSING_TOOLS+=("doxygen")
     command -v python3 >/dev/null 2>&1 || MISSING_TOOLS+=("python3")
 
-    # Check for library dependencies (platform-specific)
     MISSING_LIBS=()
     if [[ "$OS" =~ ^(ubuntu|debian)$ ]]; then
-        # Check for Ubuntu/Debian library headers
         [ -f /usr/include/pci/pci.h ] || MISSING_LIBS+=("libpci-dev")
+        [ -f /usr/include/numa.h ] || MISSING_LIBS+=("libnuma-dev")
+        [ -f /usr/include/drm/drm.h ] || MISSING_LIBS+=("libdrm-dev")
         [ -f /usr/include/yaml-cpp/yaml.h ] || MISSING_LIBS+=("libyaml-cpp-dev")
         command -v rpmbuild >/dev/null 2>&1 || MISSING_LIBS+=("rpm")
         command -v unzip >/dev/null 2>&1 || MISSING_LIBS+=("unzip")
     elif [[ "$OS" =~ ^(centos|rhel|rocky|almalinux|amzn)$ ]]; then
-        # Check for CentOS/RHEL/Rocky/AlmaLinux library headers
         [ -f /usr/include/pci/pci.h ] || MISSING_LIBS+=("pciutils-devel")
         [ -f /usr/include/yaml-cpp/yaml.h ] || MISSING_LIBS+=("yaml-cpp-devel")
         command -v rpmbuild >/dev/null 2>&1 || MISSING_LIBS+=("rpm-build")
     fi
 
-    # Combine missing tools and libraries
     MISSING_DEPS=()
     [ ${#MISSING_TOOLS[@]} -ne 0 ] && MISSING_DEPS+=("${MISSING_TOOLS[@]}")
     [ ${#MISSING_LIBS[@]} -ne 0 ] && MISSING_DEPS+=("${MISSING_LIBS[@]}")
@@ -134,11 +289,13 @@ check_and_install_dependencies() {
             apt-get install -y \
                 build-essential \
                 cmake \
+                patchelf \
                 git \
                 curl \
                 libcurl4-openssl-dev \
                 tar \
                 libnuma-dev \
+                libdrm-dev \
                 wget \
                 libpci3 \
                 libpci-dev \
@@ -151,27 +308,21 @@ check_and_install_dependencies() {
                 dpkg-dev \
                 file \
                 apt-utils
-            CMAKE_BIN="cmake"
-            CMAKE_CXX_COMPILER_OVERRIDE=""
         elif [[ "$OS" =~ ^(centos|rhel|rocky|almalinux|amzn)$ ]]; then
             print_info "Installing dependencies for CentOS/RHEL/Rocky/AlmaLinux..."
 
-            # Check if running in manylinux container (has /opt/python)
             if [ -d /opt/python ]; then
                 print_info "Detected manylinux environment - some tools may be pre-installed"
             fi
 
-            # Enable PowerTools/CRB repository (contains doxygen and yaml-cpp)
             print_info "Enabling PowerTools/CRB repository..."
             if command -v dnf >/dev/null 2>&1; then
-                # AlmaLinux/Rocky Linux 8+ uses dnf
                 dnf install -y dnf-plugins-core 2>/dev/null || true
                 dnf config-manager --set-enabled powertools 2>/dev/null || \
                 dnf config-manager --set-enabled crb 2>/dev/null || \
                 dnf config-manager --set-enabled devel 2>/dev/null || \
                 print_warning "Could not enable PowerTools/CRB/devel repo (may already be enabled)"
             else
-                # CentOS 8 uses yum
                 yum install -y yum-utils 2>/dev/null || true
                 yum-config-manager --enable powertools 2>/dev/null || \
                 yum-config-manager --enable PowerTools 2>/dev/null || \
@@ -179,12 +330,10 @@ check_and_install_dependencies() {
                 print_warning "Could not enable PowerTools/devel repo (may already be enabled)"
             fi
 
-            # Install EPEL repository (may already be present in manylinux)
             print_info "Installing EPEL repository..."
             yum install -y epel-release 2>/dev/null || print_warning "EPEL may already be installed"
 
             print_info "Installing build dependencies..."
-            # Note: manylinux typically has gcc, g++, make pre-installed
             yum install -y \
                 gcc \
                 gcc-c++ \
@@ -201,109 +350,158 @@ check_and_install_dependencies() {
                 file \
                 pciutils-devel \
                 doxygen \
-                rpm-build \
                 python3 \
                 python3-pip \
                 || print_warning "Some packages may already be installed"
 
-            # Install cmake and yaml-cpp separately as they may need special handling
             print_info "Installing cmake..."
             yum install -y cmake3 || yum install -y cmake || print_warning "cmake installation may have failed"
 
             print_info "Installing yaml-cpp..."
             yum install -y yaml-cpp-devel yaml-cpp-static 2>/dev/null || \
-            print_warning "yaml-cpp may not be available - will try to continue"
-            CMAKE_BIN="cmake3"
-            CMAKE_CXX_COMPILER_OVERRIDE="$ROCM_PATH/bin/hipcc"
+                print_warning "yaml-cpp may not be available - will try to continue"
+
+            ##
+            # Install gcc-toolset for C++20
+            if [[ "$OS" =~ ^(centos|rhel|almalinux|rocky)$ ]]; then
+                GCC_TOOLSET_INSTALLED=""
+                for ver in 14 13 12 11; do
+                    if yum list available gcc-toolset-${ver} &>/dev/null; then
+                        print_info "Found gcc-toolset-${ver} - installing for C++20 support..."
+                        if yum install -y gcc-toolset-${ver}; then
+                            GCC_TOOLSET_INSTALLED="gcc-toolset-${ver}"
+                            print_success "Installed gcc-toolset-${ver}"
+                            break
+                        fi
+                    fi
+                done
+                if [ -z "$GCC_TOOLSET_INSTALLED" ]; then
+                    if yum list available devtoolset-11 &>/dev/null; then
+                        print_info "Found devtoolset-11 - installing for C++20 support..."
+                        if yum install -y devtoolset-11; then
+                            GCC_TOOLSET_INSTALLED="devtoolset-11"
+                            print_success "Installed devtoolset-11"
+                        fi
+                    fi
+                fi
+                if [ -z "$GCC_TOOLSET_INSTALLED" ]; then
+                    print_warning "No gcc-toolset (11-14) or devtoolset-11 available"
+                fi
+            fi
         else
             print_error "Unsupported OS: $OS"
-            echo ""
-            echo "Please install the following dependencies manually:"
-            echo ""
-            echo "Build Tools:"
-            echo "  - gcc, g++, make"
-            echo "  - cmake"
-            echo "  - git"
-            echo "  - wget"
-            echo "  - tar"
-            echo "  - doxygen"
-            echo "  - python3"
-            echo ""
-            echo "Development Libraries:"
-            echo "  - libpci-dev (or pciutils-devel)"
-            echo "  - libyaml-cpp-dev (or yaml-cpp-devel)"
-            echo "  - rpm-build tools"
             exit 1
         fi
 
         print_success "Dependencies installed successfully"
         echo ""
-
-        # Verify installation by re-checking
-        print_info "Verifying installation..."
-        VERIFY_FAILED=()
-        for tool in "${MISSING_TOOLS[@]}"; do
-            if ! command -v "$tool" >/dev/null 2>&1; then
-                VERIFY_FAILED+=("$tool")
-            fi
-        done
-
-        if [ ${#VERIFY_FAILED[@]} -ne 0 ]; then
-            print_error "Failed to install: ${VERIFY_FAILED[*]}"
-            exit 1
-        fi
-        print_success "All dependencies verified"
     else
         print_success "All required dependencies found"
     fi
     echo ""
 }
 
-# Check and install dependencies (installs wget, etc. - required before fetch_latest_rocm_version)
+##
+# Check and install dependencies (installs wget etc. - required before fetch_latest_rocm_version)
+###
 check_and_install_dependencies
+ensure_recent_cmake_ubuntu
 
-# Determine ROCm version: use environment variable or fetch latest (wget is now available)
+##
+# Determine ROCm version
+###
 if [ -n "$ROCM_VERSION" ]; then
     print_info "Using specified ROCm version: $ROCM_VERSION"
-else
-    print_info "No ROCm version specified, fetching latest..."
+elif [ "$ROCM_SDK_CHANNEL" = "nightly" ]; then
+    print_info "No ROCm version specified; fetching latest from ROCm nightly index..."
+    if [ -z "$ROCM_SDK_INDEX_URL" ]; then
+        print_error "ROCM_SDK_CHANNEL=nightly requires ROCM_SDK_INDEX_URL"
+        exit 1
+    fi
     fetch_latest_rocm_version "$GPU_FAMILY"
-
-    # Validate that ROCM_VERSION was properly set
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm nightly version"
+        exit 1
+    fi
+elif [ "$ROCM_SDK_CHANNEL" = "release" ]; then
+    print_info "No ROCm version specified; fetching latest release X.Y.Z..."
+    if [ -z "$ROCM_SDK_RELEASE_URL" ]; then
+        print_error "ROCM_SDK_CHANNEL=release requires ROCM_SDK_RELEASE_URL"
+        exit 1
+    fi
+    fetch_latest_rocm_release_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm release version"
+        exit 1
+    fi
+elif [ -n "$ROCM_SDK_RELEASE_URL" ]; then
+    print_info "No ROCm version specified; resolving latest release..."
+    fetch_latest_rocm_release_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm release version"
+        exit 1
+    fi
+elif [ -n "$ROCM_SDK_INDEX_URL" ]; then
+    print_info "No ROCm version specified, fetching latest from nightly index..."
+    fetch_latest_rocm_version "$GPU_FAMILY"
     if [ -z "$ROCM_VERSION" ]; then
         print_error "Failed to determine ROCm version"
         exit 1
     fi
+else
+    print_error "ROCM_VERSION is required"
+    print_info "Set ROCM_VERSION, or configure ROCM_SDK_RELEASE_URL or ROCM_SDK_INDEX_URL"
+    echo ""
+    echo "  export ROCM_VERSION=\"7.11.0a20260121\""
+    echo "  ./build_packages_local.sh"
+    echo ""
+    exit 1
 fi
 
+apply_sdk_tarball_base_for_version "$ROCM_VERSION"
+
+##
 # Print configuration
 echo "================================================================================"
 echo "  ROCm Bandwidth Test (RBT) - Local Package Build Script"
 echo "================================================================================"
 print_info "ROCm Version: $ROCM_VERSION"
+print_info "ROCm SDK channel: ${ROCM_SDK_CHANNEL:-auto}"
 print_info "GPU Family: $GPU_FAMILY"
 print_info "Build Type: $BUILD_TYPE"
 print_info "Build Directory: $BUILD_DIR"
 print_info "ROCm Install: $ROCM_INSTALL_DIR"
-print_info "RBT Version: Will be read from CMakeLists.txt by CMake/CPack"
+print_info "SDK Source: $ROCM_SDK_BASE_URL"
+if [ -n "$UPLOAD_TARGET" ]; then
+    print_info "Upload Target: $UPLOAD_TARGET"
+fi
 echo "================================================================================"
 echo ""
 
+##
 # Step 1: Download ROCm SDK
 print_info "Step 1: Downloading ROCm SDK tarball..."
-TARBALL_URL="https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz"
+TARBALL_URL=$(join_base_and_file "$ROCM_SDK_BASE_URL" "therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz")
 TARBALL_FILE="$ROCM_INSTALL_DIR/rocm-sdk.tar.gz"
 
 mkdir -p "$ROCM_INSTALL_DIR"
 
 if [ -f "$ROCM_INSTALL_DIR/install/bin/hipconfig" ]; then
     print_warning "ROCm SDK already exists at $ROCM_INSTALL_DIR/install"
-    read -p "Do you want to re-download? (y/N): " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        rm -rf "$ROCM_INSTALL_DIR/install"
+    if [ -t 0 ]; then
+        read -p "Do you want to re-download? (y/N): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            rm -rf "$ROCM_INSTALL_DIR/install"
+        else
+            print_info "Using existing ROCm SDK"
+            export ROCM_PATH="$ROCM_INSTALL_DIR/install"
+            print_success "ROCm SDK path set to: $ROCM_PATH"
+            echo ""
+            goto_step2=true
+        fi
     else
-        print_info "Using existing ROCm SDK"
+        print_info "Non-interactive mode: reusing existing ROCm SDK"
         export ROCM_PATH="$ROCM_INSTALL_DIR/install"
         print_success "ROCm SDK path set to: $ROCM_PATH"
         echo ""
@@ -319,11 +517,9 @@ if [ -z "$goto_step2" ]; then
     else
         print_error "Failed to download ROCm SDK tarball"
         print_error "URL: $TARBALL_URL"
-        print_info "Please check if the ROCm version and GPU family are correct"
         exit 1
     fi
 
-    # Extract tarball
     print_info "Extracting ROCm SDK..."
     mkdir -p "$ROCM_INSTALL_DIR/install"
     tar -xzf "$TARBALL_FILE" -C "$ROCM_INSTALL_DIR/install" --strip-components=1
@@ -334,127 +530,145 @@ if [ -z "$goto_step2" ]; then
 fi
 echo ""
 
+##
 # Step 2: Setup environment
 print_info "Step 2: Setting up ROCm environment..."
-
-# Find HIP device library path (amdgcn/bitcode) first
 print_info "Locating HIP device libraries (amdgcn/bitcode)..."
 HIP_DEVICE_LIB_PATH=$(find "$ROCM_PATH" -type d -path "*/amdgcn/bitcode" 2>/dev/null | head -1)
 
 if [ -z "$HIP_DEVICE_LIB_PATH" ]; then
     print_error "Could not find amdgcn/bitcode directory in $ROCM_PATH"
-    print_error "HIP device libraries are required for GPU code compilation"
-    print_error "Please verify your ROCm SDK installation"
     exit 1
 fi
 
-# Export all environment variables
-export PATH="$ROCM_PATH/bin:$PATH"
-export LD_LIBRARY_PATH="$ROCM_PATH/lib:$LD_LIBRARY_PATH"
-export CMAKE_PREFIX_PATH="$ROCM_PATH:$CMAKE_PREFIX_PATH"
-export HIP_DEVICE_LIB_PATH="$HIP_DEVICE_LIB_PATH"
+export PATH="${ROCM_PATH}/bin:${PATH}"
+export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+export CMAKE_PREFIX_PATH="${ROCM_PATH}:${CMAKE_PREFIX_PATH:-}"
+export HIP_DEVICE_LIB_PATH="${HIP_DEVICE_LIB_PATH}"
 
-# Extract major.minor version from ROCM_VERSION for ROCM_LIBPATCH_VERSION
-# Convert to xxyy format with zero padding
-# Example: "7.11.0a20260121" -> "0711", "8.0.0" -> "0800", "10.2.0" -> "1002"
 ROCM_VERSION_MAJOR_MINOR=$(echo "$ROCM_VERSION" | grep -oP '^\d+\.\d+')
 if [ -z "$ROCM_VERSION_MAJOR_MINOR" ]; then
     print_error "Could not extract major.minor version from ROCM_VERSION: $ROCM_VERSION"
     exit 1
 fi
 
-# Split into major and minor, zero-pad to 2 digits each
 ROCM_MAJOR=$(echo "$ROCM_VERSION_MAJOR_MINOR" | cut -d'.' -f1)
 ROCM_MINOR=$(echo "$ROCM_VERSION_MAJOR_MINOR" | cut -d'.' -f2)
 ROCM_LIBPATCH_VERSION=$(printf "%02d%02d" "$ROCM_MAJOR" "$ROCM_MINOR")
 
 export ROCM_LIBPATCH_VERSION
-print_success "Set ROCM_LIBPATCH_VERSION=$ROCM_LIBPATCH_VERSION (from $ROCM_VERSION_MAJOR_MINOR)"
+export ROCM_MAJOR
+print_success "Set ROCM_LIBPATCH_VERSION=$ROCM_LIBPATCH_VERSION, ROCM_MAJOR=$ROCM_MAJOR"
 
-# Set CPACK package release based on branch type
-# - Non-release branches (not starting with "rel"): use branch.commit format
-# - Release branches (starting with "rel"): use GitHub run number
-GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-GIT_COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "0000000")
-
-if [[ "$GIT_BRANCH" =~ ^rel ]]; then
-    # Release branch: use GitHub run number (fallback to 1 for local builds)
-    GITHUB_RUN_NUMBER="${GITHUB_RUN_NUMBER:-1}"
-    PACKAGE_RELEASE="$GITHUB_RUN_NUMBER"
-
-    export CPACK_DEBIAN_PACKAGE_RELEASE="$PACKAGE_RELEASE"
-    export CPACK_RPM_PACKAGE_RELEASE="$PACKAGE_RELEASE"
-
-    print_success "Set CPACK package release: $PACKAGE_RELEASE (release branch: $GIT_BRANCH, run: $GITHUB_RUN_NUMBER)"
-else
-    # Development branch: use branch name and commit
-    # Sanitize branch name: replace / and other special chars with -
-    SANITIZED_BRANCH=$(echo "$GIT_BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
-    PACKAGE_RELEASE="${SANITIZED_BRANCH}.${GIT_COMMIT_SHORT}"
-
-    export CPACK_DEBIAN_PACKAGE_RELEASE="$PACKAGE_RELEASE"
-    export CPACK_RPM_PACKAGE_RELEASE="$PACKAGE_RELEASE"
-
-    print_success "Set CPACK package release: $PACKAGE_RELEASE (dev branch: $GIT_BRANCH, commit: $GIT_COMMIT_SHORT)"
+##
+# Git safe directory (for Actions containers)
+if [ -n "${GITHUB_WORKSPACE:-}" ] && command -v git >/dev/null 2>&1; then
+    git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 fi
 
-# TODO: Currently hipcc and cmake3 are only set for AlmaLinux (manylinux_2_28)
-# Ubuntu works fine without these settings. Need to verify later if these
-# should be applied universally for all OS or kept OS-specific.
+RELEASE_DATE="$(date +%Y%m%d)"
+BASE_PACKAGE_RELEASE="r${ROCM_LIBPATCH_VERSION}.${RELEASE_DATE}"
 
-# AlmaLinux-specific settings for manylinux_2_28
-if [[ "$OS" == "almalinux" ]]; then
-    # Set C++ compiler to hipcc from ROCm for AlmaLinux
-    if [ -x "$ROCM_PATH/bin/hipcc" ]; then
-        export CMAKE_CXX_COMPILER="$ROCM_PATH/bin/hipcc"
-        print_success "Set CMAKE_CXX_COMPILER to hipcc (AlmaLinux)"
-    else
-        print_warning "hipcc not found at $ROCM_PATH/bin/hipcc - using system default compiler"
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "${GITHUB_HEAD_REF:-}" ]; then
+    GIT_BRANCH="${GITHUB_HEAD_REF}"
+else
+    GIT_BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")}"
+fi
+if [ -n "$GITHUB_SHA" ]; then
+    GIT_COMMIT_SHORT="${GITHUB_SHA:0:7}"
+else
+    GIT_COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "0000000")
+fi
+SANITIZED_BRANCH=$(echo "$GIT_BRANCH" | sed 's/[^A-Za-z0-9.+~]/./g')
+
+if [ "${GITHUB_EVENT_NAME}" != "pull_request" ] && [[ "$GIT_BRANCH" =~ ^rel ]]; then
+    GITHUB_RUN_NUMBER="${GITHUB_RUN_NUMBER:-1}"
+    PACKAGE_RELEASE="$GITHUB_RUN_NUMBER"
+    print_success "Set CPACK package release: $PACKAGE_RELEASE (release branch)"
+elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+    PACKAGE_RELEASE="${BASE_PACKAGE_RELEASE}.${SANITIZED_BRANCH}.${GIT_COMMIT_SHORT}"
+    print_success "Set CPACK package release: $PACKAGE_RELEASE (PR)"
+else
+    PACKAGE_RELEASE="$BASE_PACKAGE_RELEASE"
+    print_success "Set CPACK package release: $PACKAGE_RELEASE"
+fi
+
+export CPACK_DEBIAN_PACKAGE_RELEASE="$PACKAGE_RELEASE"
+export CPACK_RPM_PACKAGE_RELEASE="$PACKAGE_RELEASE"
+
+if [[ "$OS" =~ ^(centos|rhel|almalinux|rocky)$ ]]; then
+    GCC_TOOLSET_ENABLED=""
+    for pkg in gcc-toolset-14 gcc-toolset-13 gcc-toolset-12 gcc-toolset-11 devtoolset-11; do
+        ENABLE_SCRIPT=$(rpm -ql ${pkg}-runtime 2>/dev/null | grep '/enable$' | head -1)
+        if [ -n "$ENABLE_SCRIPT" ] && [ -f "$ENABLE_SCRIPT" ]; then
+            TOOLSET_ROOT=$(dirname "$ENABLE_SCRIPT")
+            source "$ENABLE_SCRIPT"
+            export GCC_TOOLCHAIN="${TOOLSET_ROOT}/root/usr"
+            GCC_TOOLSET_ENABLED="$pkg"
+            print_success "Enabled ${pkg} from ${TOOLSET_ROOT}"
+            break
+        fi
+    done
+    if [ -z "$GCC_TOOLSET_ENABLED" ]; then
+        print_warning "No gcc-toolset found"
     fi
 
-    # Use cmake3 for AlmaLinux
+    if [ -x "$ROCM_PATH/bin/hipcc" ]; then
+        export CMAKE_CXX_COMPILER="$ROCM_PATH/bin/hipcc"
+        print_success "Set CMAKE_CXX_COMPILER to hipcc"
+    fi
+
     export CMAKE_COMMAND="cmake3"
-    print_info "Using cmake3 (AlmaLinux/Manylinux)"
+    print_info "Using cmake3"
 else
-    # Ubuntu: use defaults (system compiler and cmake)
     export CMAKE_COMMAND="cmake"
-    print_info "Using cmake (Ubuntu)"
+    print_info "Using cmake"
+
+    if [[ "$OS" =~ ^(ubuntu|debian)$ ]]; then
+        if [ -x "$ROCM_PATH/bin/hipcc" ]; then
+            export CMAKE_CXX_COMPILER="$ROCM_PATH/bin/hipcc"
+            print_success "Set CMAKE_CXX_COMPILER to hipcc"
+        fi
+        if compgen -G "/usr/include/c++/*/barrier" >/dev/null 2>&1; then
+            export GCC_TOOLCHAIN="/usr"
+            print_success "Set GCC_TOOLCHAIN=/usr so hipcc finds system libstdc++ (C++20 <barrier>)"
+        else
+            print_warning "No /usr/include/c++/.../barrier found; install g++ 11+ (e.g. apt install g++-11 build-essential)"
+        fi
+    fi
 fi
 
 print_info "Environment variables set:"
 echo "  ROCM_PATH=$ROCM_PATH"
-echo "  PATH includes: $ROCM_PATH/bin"
-echo "  LD_LIBRARY_PATH includes: $ROCM_PATH/lib"
 echo "  HIP_DEVICE_LIB_PATH=$HIP_DEVICE_LIB_PATH"
 echo "  ROCM_LIBPATCH_VERSION=$ROCM_LIBPATCH_VERSION"
-if [ -n "$CPACK_DEBIAN_PACKAGE_RELEASE" ]; then
-    echo "  CPACK_DEBIAN_PACKAGE_RELEASE=$CPACK_DEBIAN_PACKAGE_RELEASE"
-fi
-if [ -n "$CPACK_RPM_PACKAGE_RELEASE" ]; then
-    echo "  CPACK_RPM_PACKAGE_RELEASE=$CPACK_RPM_PACKAGE_RELEASE"
-fi
-if [ -n "$CMAKE_CXX_COMPILER" ]; then
+if [ -n "${CMAKE_CXX_COMPILER:-}" ]; then
     echo "  CMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER"
+fi
+if [ -n "${GCC_TOOLCHAIN:-}" ]; then
+    echo "  GCC_TOOLCHAIN=$GCC_TOOLCHAIN"
 fi
 echo "  CMAKE_COMMAND=$CMAKE_COMMAND"
 
+##
 # Verify ROCm installation
 print_info "Verifying ROCm installation..."
 if [ -x "$ROCM_PATH/bin/hipconfig" ]; then
     print_success "hipconfig found"
 else
-    print_warning "hipconfig not found or not executable"
+    print_warning "hipconfig not found"
 fi
 
 if [ -d "$ROCM_PATH/lib" ]; then
     LIB_COUNT=$(ls -1 "$ROCM_PATH/lib"/*.so 2>/dev/null | wc -l)
-    print_success "Found $LIB_COUNT shared libraries in $ROCM_PATH/lib"
+    print_success "Found $LIB_COUNT shared libraries"
 else
     print_error "ROCm lib directory not found"
     exit 1
 fi
 echo ""
 
+##
 # Step 3: Configure CMake
 print_info "Step 3: Configuring CMake with relocatable paths..."
 if [ -d "$BUILD_DIR" ]; then
@@ -462,25 +676,18 @@ if [ -d "$BUILD_DIR" ]; then
     rm -rf "$BUILD_DIR"
 fi
 
-# -------- configure --------
 INSTALL_PREFIX="/opt/rocm/extras-${ROCM_MAJOR}"
-# Relocatable RPATH: $ORIGIN-relative + install prefix + the conventional
-# install-time ROCm locations. Do NOT embed ${ROCM_PATH} (the ephemeral
-# build-time SDK download path) — that would leak CI paths into the
-# packaged binary and break relocatability.
 RPATH_LIST="\$ORIGIN:\$ORIGIN/../lib:${INSTALL_PREFIX}/lib:/opt/rocm/lib:/opt/rocm/lib64"
 
-print_info "Configuring CMake..."
-rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 
-# Build cmake command with optional CXX compiler
 CMAKE_ARGS=(
     -B "$BUILD_DIR"
-    ##-S "$REPO_ROOT"
     -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
     -DROCM_PATH="$ROCM_PATH"
+    -DROCM_MAJOR_VERSION="$ROCM_MAJOR"
     -DHIP_PLATFORM=amd
+
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"
     -DCPACK_PACKAGING_INSTALL_PREFIX="${INSTALL_PREFIX}"
     -DCMAKE_SKIP_RPATH=FALSE
@@ -495,53 +702,215 @@ CMAKE_ARGS=(
     -DCMAKE_MODULE_PATH="${ROCM_BANDWIDTH_TEST_ROOT}/cmake/modules"
 )
 
-# Add CXX compiler if set
-if [[ -n "${CMAKE_CXX_COMPILER_OVERRIDE}" ]]; then
-  CMAKE_ARGS+=(-DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER_OVERRIDE}")
+if [ -n "${CMAKE_CXX_COMPILER:-}" ]; then
+    CMAKE_ARGS+=(-DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER}")
 fi
 
-"${CMAKE_BIN}" "${CMAKE_ARGS[@]}"
-print_info "CMake configured"
+if [ -n "${GCC_TOOLCHAIN:-}" ]; then
+    CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="--gcc-toolchain=$GCC_TOOLCHAIN")
+    print_success "Set --gcc-toolchain=$GCC_TOOLCHAIN"
+fi
 
+$CMAKE_COMMAND "${CMAKE_ARGS[@]}"
 
+if [ $? -eq 0 ]; then
+    print_success "CMake configuration successful"
+else
+    print_error "CMake configuration failed"
+    exit 1
+fi
+echo ""
+
+##
 # Step 4: Build RBT
 print_info "Step 4: Building RBT..."
 NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 print_info "Using $NPROC parallel jobs"
 
-"${CMAKE_BIN}" --build "${BUILD_DIR}" -- -j"$(nproc)"
+make -C "$BUILD_DIR" -j"$NPROC"
+
+if [ $? -eq 0 ]; then
+    print_success "Build successful"
+else
+    print_error "Build failed"
+    exit 1
+fi
 echo ""
 
+##
 # Step 5: Create packages
-print_info "Step 5: Creating packages... (DEB / RPM / TGZ via CPack)..."
+print_info "Step 5: Creating packages..."
 
-# Create DEB package (Ubuntu/Debian)
 cd "$BUILD_DIR"
-if [[ "${DISTRO}" == "ubuntu" ]]; then
+
+##
+# DEB: when dpkg-deb is available (Debian/Ubuntu and manylinux with dpkg installed)
+if command -v dpkg-deb >/dev/null 2>&1; then
     print_info "Creating DEB package..."
     cpack -G DEB --verbose
-    cpack -G TGZ --verbose
 
-else
-# Create RPM package (CentOS/RHEL/SLES)
+    if [ $? -eq 0 ]; then
+        DEB_FILE=$(ls amdrocm*-rbt*.deb 2>/dev/null | head -1)
+        if [ -n "$DEB_FILE" ]; then
+            print_success "Created DEB package: $DEB_FILE"
+            DEB_SIZE=$(du -h "$DEB_FILE" | cut -f1)
+            print_info "Package size: $DEB_SIZE"
+
+            print_info "Verifying DEB package..."
+            dpkg-deb -I "$DEB_FILE" | head -20
+        fi
+    else
+        print_warning "DEB package creation failed"
+    fi
+fi
+
+##
+# RPM: when rpmbuild is available (RPM-based systems)
+if command -v rpmbuild >/dev/null 2>&1; then
     print_info "Creating RPM package..."
     cpack -G RPM --verbose
-    cpack -G TGZ --verbose
+
+    if [ $? -eq 0 ]; then
+        RPM_FILE=$(ls amdrocm*-rbt*.rpm 2>/dev/null | head -1)
+        if [ -n "$RPM_FILE" ]; then
+            print_success "Created RPM package: $RPM_FILE"
+            RPM_SIZE=$(du -h "$RPM_FILE" | cut -f1)
+            print_info "Package size: $RPM_SIZE"
+
+            print_info "Verifying RPM package..."
+            rpm -qip "$RPM_FILE" | head -20
+        fi
+    else
+        print_warning "RPM package creation failed"
+    fi
+fi
+
+##
+# TGZ: always built; cmake already configured CPACK_GENERATOR="DEB;RPM;TGZ"
+# for AMD_APP_BUILD_RELOCATABLE_PACKAGE=ON — no second cmake pass needed.
+print_info "Creating TGZ package..."
+cpack -G TGZ --verbose
+
+if [ $? -eq 0 ]; then
+    TGZ_FILE=$(ls amdrocm*-rbt*.tar.gz 2>/dev/null | head -1)
+    if [ -n "$TGZ_FILE" ]; then
+        print_success "Created TGZ package: $TGZ_FILE"
+        TGZ_SIZE=$(du -h "$TGZ_FILE" | cut -f1)
+        print_info "Package size: $TGZ_SIZE"
+    fi
+else
+    print_error "TGZ package creation failed"
 fi
 
 cd - > /dev/null
-ls -lh "${BUILD_DIR}"/amdrocm*-rocm-bandwidth-test* 2>/dev/null ||
-ls -lh "${BUILD_DIR}"/*.deb "${BUILD_DIR}"/*.rpm "${BUILD_DIR}"/*.tar.gz 2>/dev/null || true
 echo ""
 
+##
+# Step 6: Upload packages (optional)
+if [ -n "$UPLOAD_TARGET" ]; then
+    print_info "Step 6: Uploading packages to $UPLOAD_TARGET..."
+
+    if [ -z "$UPLOAD_REPO" ]; then
+        UPLOAD_REPO="${GITHUB_REPOSITORY##*/}"
+        [ -z "$UPLOAD_REPO" ] && UPLOAD_REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*/||; s|\.git$||')
+        [ -z "$UPLOAD_REPO" ] && UPLOAD_REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)
+        [ -z "$UPLOAD_REPO" ] && UPLOAD_REPO="rocm_bandwidth_test"
+    fi
+    UPLOAD_BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")}"
+    UPLOAD_BRANCH=$(echo "$UPLOAD_BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g')
+    UPLOAD_DATE=$(date +%Y-%m-%d)
+    UPLOAD_SUBPATH="${UPLOAD_REPO}/${UPLOAD_BRANCH}/${UPLOAD_DATE}"
+
+    print_info "Upload path: .../${UPLOAD_SUBPATH}/"
+
+    PKGS=$(find "$BUILD_DIR" -maxdepth 1 -name 'amdrocm*-rbt*' \( -name '*.deb' -o -name '*.rpm' -o -name '*.tar.gz' \) 2>/dev/null)
+    if [ -z "$PKGS" ]; then
+        print_error "No packages found to upload"
+    else
+        UPLOAD_OK=true
+
+        case "$UPLOAD_TARGET" in
+            scp://*)
+                SCP_DEST="${UPLOAD_TARGET#scp://}"
+                SCP_DEST="${SCP_DEST%/}/${UPLOAD_SUBPATH}/"
+                print_info "Uploading via SCP to $SCP_DEST"
+                SCP_HOST="${SCP_DEST%%:*}"
+                SCP_PATH="${SCP_DEST#*:}"
+                ssh "$SCP_HOST" "mkdir -p '$SCP_PATH'" 2>/dev/null || true
+                for pkg in $PKGS; do
+                    print_info "  $(basename "$pkg")"
+                    if ! scp "$pkg" "$SCP_DEST"; then
+                        print_error "SCP upload failed for $(basename "$pkg")"
+                        UPLOAD_OK=false
+                    fi
+                done
+                ;;
+            rsync://*)
+                RSYNC_DEST="${UPLOAD_TARGET#rsync://}"
+                RSYNC_DEST="${RSYNC_DEST%/}/${UPLOAD_SUBPATH}/"
+                print_info "Uploading via rsync to $RSYNC_DEST"
+                if ! echo "$PKGS" | xargs -I{} rsync -avz --progress {} "$RSYNC_DEST"; then
+                    print_error "Rsync upload failed"
+                    UPLOAD_OK=false
+                fi
+                ;;
+            http://*|https://*)
+                UPLOAD_URL="${UPLOAD_TARGET%/}/${UPLOAD_SUBPATH}"
+                print_info "Uploading via HTTP PUT to $UPLOAD_URL/"
+                for pkg in $PKGS; do
+                    local_name=$(basename "$pkg")
+                    print_info "  $local_name"
+                    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                        -X PUT -T "$pkg" \
+                        "${UPLOAD_URL}/${local_name}")
+                    if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+                        print_success "  Uploaded $local_name (HTTP $HTTP_CODE)"
+                    else
+                        print_error "  Failed to upload $local_name (HTTP $HTTP_CODE)"
+                        UPLOAD_OK=false
+                    fi
+                done
+                if [[ "$UPLOAD_TARGET" =~ localhost|127\.0\.0\.1 ]]; then
+                    SHARE_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | grep -oP 'src \K[0-9.]+' | head -1)
+                    [ -z "$SHARE_IP" ] && SHARE_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+                    if [ -n "$SHARE_IP" ]; then
+                        SHARE_URL=$(echo "$UPLOAD_URL" | sed "s|localhost|$SHARE_IP|;s|127\.0\.0\.1|$SHARE_IP|")
+                        print_info "Share this URL: ${SHARE_URL}/"
+                    fi
+                fi
+                print_info "Browse uploads: ${UPLOAD_URL}/"
+                ;;
+            *)
+                LOCAL_DEST="${UPLOAD_TARGET%/}/${UPLOAD_SUBPATH}"
+                print_info "Copying packages to $LOCAL_DEST"
+                mkdir -p "$LOCAL_DEST"
+                for pkg in $PKGS; do
+                    print_info "  $(basename "$pkg")"
+                    if ! cp "$pkg" "$LOCAL_DEST/"; then
+                        print_error "Copy failed for $(basename "$pkg")"
+                        UPLOAD_OK=false
+                    fi
+                done
+                ;;
+        esac
+
+        if [ "$UPLOAD_OK" = true ]; then
+            print_success "All packages uploaded successfully"
+        else
+            print_warning "Some uploads failed"
+        fi
+    fi
+    echo ""
+fi
+
+##
 # Summary
 echo "================================================================================"
 print_success "Package build completed successfully!"
 echo "================================================================================"
 print_info "Generated packages are in: $BUILD_DIR"
 echo ""
-# List only package types that were actually generated (DEB on Ubuntu, RPM on CentOS/RHEL, TGZ on all)
-PKGS=$(find "$BUILD_DIR" -maxdepth 1 -name 'rocm-bandwidth-test*' \( -name '*.deb' -o -name '*.rpm' -o -name '*.tar.gz' \) 2>/dev/null)
+PKGS=$(find "$BUILD_DIR" -maxdepth 1 -name "amdrocm*-rbt*" \( -name '*.deb' -o -name '*.rpm' -o -name '*.tar.gz' \) 2>/dev/null)
 if [ -n "$PKGS" ]; then
     echo "$PKGS" | xargs ls -lh
 else
@@ -549,21 +918,23 @@ else
 fi
 echo ""
 
+##
 # Installation instructions
 echo "================================================================================"
 echo "  Installation Instructions"
 echo "================================================================================"
 echo ""
 echo "Ubuntu/Debian (DEB):"
-echo "  sudo dpkg -i $BUILD_DIR/rocm-bandwidth-test_*.deb"
+echo "  sudo dpkg -i $BUILD_DIR/amdrocm${ROCM_MAJOR}-rbt_*.deb"
 echo ""
 echo "CentOS/RHEL (RPM):"
-echo "  sudo rpm -i --replacefiles --nodeps $BUILD_DIR/rocm-bandwidth-test-*.rpm"
+echo "  sudo rpm -i --replacefiles --nodeps $BUILD_DIR/amdrocm${ROCM_MAJOR}-rbt-*.rpm"
 echo ""
 echo "Any Linux (TGZ - Relocatable):"
-echo "  sudo tar -xzf $BUILD_DIR/rocm-bandwidth-test-*.tar.gz -C /"
-echo "  export PATH=/opt/rocm/rbt/bin:\$PATH"
-echo "  export LD_LIBRARY_PATH=/opt/rocm/rbt/lib:\$LD_LIBRARY_PATH"
+echo "  sudo mkdir -p /opt/rocm/extras-${ROCM_MAJOR}"
+echo "  sudo tar -xzf $BUILD_DIR/amdrocm${ROCM_MAJOR}-rbt-*.tar.gz -C /opt/rocm/extras-${ROCM_MAJOR}"
+echo "  export PATH=/opt/rocm/extras-${ROCM_MAJOR}/bin:\$PATH"
+echo "  export LD_LIBRARY_PATH=/opt/rocm/extras-${ROCM_MAJOR}/lib:\$LD_LIBRARY_PATH"
 echo ""
 echo "================================================================================"
 

--- a/cmake/build_utils.cmake
+++ b/cmake/build_utils.cmake
@@ -1427,21 +1427,17 @@ macro(setup_distribution_package)
         endif()
         string(REPLACE "_" "-" AMD_TARGET_BUNDLE_BASE_NAME "${AMD_TARGET_BUNDLE_BASE_NAME}")
 
+        set(AMD_TARGET_PKG_SHORT_NAME "rbt")
         set(AMD_TARGET_INSTALL_STAGING "/var/tmp/${AMD_TARGET_NAME}/_staging")
         set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md")
-        set(CPACK_PACKAGE_NAME "amdrocm${ROCM_MAJOR_VERSION}-${AMD_TARGET_BUNDLE_BASE_NAME}")
+        set(CPACK_PACKAGE_NAME "amdrocm${ROCM_MAJOR_VERSION}-${AMD_TARGET_PKG_SHORT_NAME}")
 
         ## Standard package directives for all package build types
         string(TIMESTAMP CURRENT_BUILD_YEAR "%Y")
         set(AMD_PROJECT_COPYRIGHT_ORGANIZATION "Advanced Micro Devices, Inc. All rights reserved.")
         set(AMD_PROJECT_COPYRIGHT_NOTE "Copyright (c) ${CURRENT_BUILD_YEAR} ${AMD_PROJECT_COPYRIGHT_ORGANIZATION}")
-
         set(CPACK_PACKAGE_VENDOR ${AMD_PROJECT_AUTHOR_ORGANIZATION})
-        set(CPACK_PACKAGE_VERSION_MAJOR ${AMD_PROJECT_VERSION_MAJOR})
-        set(CPACK_PACKAGE_VERSION_MINOR ${AMD_PROJECT_VERSION_MINOR})
-        set(CPACK_PACKAGE_VERSION_PATCH ${AMD_PROJECT_VERSION_PATCH})
         set(CPACK_PACKAGE_CONTACT ${AMD_PROJECT_AUTHOR_MAINTAINER})
-        set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
 
         # Debian package specific variables
         set(CPACK_DEBIAN_PACKAGE_HOMEPAGE ${AMD_PROJECT_GITHUB_REPO})
@@ -1478,10 +1474,6 @@ macro(setup_distribution_package)
             set(ROCM_MAJOR_VERSION "7")
         endif()
 
-        if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
-            set(CPACK_RPM_PACKAGE_RELEASE "$ENV{CPACK_RPM_PACKAGE_RELEASE}")
-        endif()
-
         # Use the actual install prefix (caller-controlled in relocatable mode)
         # rather than hard-coded /opt/... paths.
         if(DEFINED CPACK_PACKAGING_INSTALL_PREFIX)
@@ -1496,13 +1488,21 @@ macro(setup_distribution_package)
         )
 
         #
+        set(CPACK_PACKAGE_VERSION_MAJOR ${AMD_PROJECT_VERSION_MAJOR})
+        set(CPACK_PACKAGE_VERSION_MINOR ${AMD_PROJECT_VERSION_MINOR})
+        set(CPACK_PACKAGE_VERSION_PATCH ${AMD_PROJECT_VERSION_PATCH})
+        set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+        set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ROCm utility tool for benchmarking device performance")
+
         ## DEB
         set(CPACK_DEBIAN_PACKAGE_NAME       "${CPACK_PACKAGE_NAME}")
         set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
         set(CPACK_DEBIAN_PACKAGE_DEPENDS    "numactl, libnuma1, hsa-rocr, libstdc++6")
         set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_CONTACT}")
-        if(DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
-            set(CPACK_DEBIAN_PACKAGE_RELEASE "$ENV{CPACK_DEBIAN_PACKAGE_RELEASE}")
+        if (DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
+            set(CPACK_DEBIAN_PACKAGE_RELEASE $ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
+        else()
+            set(CPACK_DEBIAN_PACKAGE_RELEASE "local")
         endif()
 
         #
@@ -1511,21 +1511,25 @@ macro(setup_distribution_package)
         set(CPACK_RPM_PACKAGE_LICENSE "MIT")
         set(CPACK_RPM_PACKAGE_REQUIRES "numactl, hsa-rocr")
         set(CPACK_RPM_PACKAGE_VENDOR  "${CPACK_PACKAGE_VENDOR}")
+        if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
+            set(CPACK_RPM_PACKAGE_RELEASE $ENV{CPACK_RPM_PACKAGE_RELEASE})
+        else()
+            set(CPACK_RPM_PACKAGE_RELEASE "local")
+        endif()
+
+        # distro changes
+        if(CPACK_RPM_PACKAGE_RELEASE)
+            set(CPACK_RPM_PACKAGE_RELEASE_DIST ON)
+        endif()
 
         #
-        ##
-        set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ROCm utility tool for benchmarking device performance")
-
-        #
-        ## TGZ
-        set(CPACK_ARCHIVE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-Linux")
+        ## TGZ (STGZ): same version + release scheme as DEB/RPM — <name>-<ver>-<release>-Linux.tar.gz
+        ## CPACK_RPM_PACKAGE_RELEASE is set from the build script (e.g. r0711.20260423 or PR suffix)
+        set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}-Linux" CACHE STRING "STGZ/CPack output file stem" FORCE)
+        ##set(CPACK_ARCHIVE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}+Linux")
         set(CPACK_GENERATOR "DEB;RPM;TGZ")
 
-        if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
-            set(ROCM_VERSION_FOR_PACKAGE $ENV{ROCM_LIBPATCH_VERSION})
-        endif()
         set(CPACK_SOURCE_IGNORE_FILES "${AMD_TARGET_INSTALL_STAGING}/;${CPACK_SOURCE_IGNORE_FILES}")
-        set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION}.${ROCM_VERSION_FOR_PACKAGE}")
         set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ROCm utility tool for benchmarking device performance")
 
     else()

--- a/rbt_nightly_test.sh
+++ b/rbt_nightly_test.sh
@@ -1,0 +1,512 @@
+#!/bin/bash
+################################################################################
+# Remote RBT nightly install + test driver (used by rbt-nightly-tests.yml).
+# Mirrors build_packages_local.sh: workflow orchestrates, this script executes.
+################################################################################
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: rbt_nightly_test.sh <command>
+
+Commands (workflow order):
+  validate-config     Fail fast; emit prepare job outputs to GITHUB_OUTPUT
+  setup-ssh           Write SSH key/config under RUNNER_TEMP and verify connectivity
+  verify-rocm         Remote rocminfo + amd-smi on TARGET_ROCM_PATH
+  download-tarball    curl tarball to ./pkg/ on the orchestrator runner
+  copy-to-target      scp tarball to REMOTE_WORK_DIR/pkg on target
+  install-rbt         Extract tarball on target under INSTALL_DIR
+  verify-rbt-binary   Remote ldd check on RBT_BIN
+  run-tests           Run healthcheck, p2p, topology; write rc/start/end to GITHUB_OUTPUT
+  collect-logs        scp remote logs to ./reports/
+  capture-versions    Write rbt_version and target_rocm_version to GITHUB_OUTPUT
+  build-report        Write ./reports/SUMMARY.md from env + prior outputs
+  cleanup-remote      rm -rf REMOTE_WORK_DIR on target
+  cleanup-local-ssh   Remove workflow-scoped key/config files
+EOF
+}
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "::error::Required environment variable $name is not set" >&2
+    exit 1
+  fi
+}
+
+ld_path_export() {
+  echo "${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib"
+}
+
+cmd_validate_config() {
+  require_env TARBALL_NAME
+  require_env TARGET_NODE
+  require_env TARGET_ROCM_PATH
+
+  local input_remote="${INPUT_REMOTE_WORK_DIR:-}"
+  local var_remote="${VAR_REMOTE_WORK_DIR:-}"
+  local run_id="${GITHUB_RUN_ID:-local}"
+
+  if [ -n "$input_remote" ]; then
+    REMOTE_WORK_DIR="$input_remote"
+  elif [ -n "$var_remote" ]; then
+    REMOTE_WORK_DIR="$var_remote"
+  else
+    REMOTE_WORK_DIR="/tmp/rbt-nightly-${run_id}"
+  fi
+
+  if [[ "$TARBALL_NAME" =~ ^amdrocm([0-9]+)- ]]; then
+    ROCM_MAJOR="${BASH_REMATCH[1]}"
+  else
+    echo "::error::Cannot parse ROCm major version from tarball name: $TARBALL_NAME" >&2
+    exit 1
+  fi
+
+  INSTALL_DIR="/opt/rocm/extras-${ROCM_MAJOR}"
+  RBT_BIN="${INSTALL_DIR}/bin/rocm_bandwidth_test"
+
+  echo "Orchestrator runner : $(hostname)"
+  echo "Target node         : ${TARGET_USER:-}@${TARGET_NODE}"
+  echo "Target ROCm path    : $TARGET_ROCM_PATH"
+  echo "Remote work dir     : $REMOTE_WORK_DIR"
+  echo "ROCm major          : $ROCM_MAJOR"
+  echo "Expected RBT binary : $RBT_BIN"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "remote_work_dir=$REMOTE_WORK_DIR"
+      echo "rocm_major=$ROCM_MAJOR"
+      echo "install_dir=$INSTALL_DIR"
+      echo "rbt_bin=$RBT_BIN"
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  export REMOTE_WORK_DIR ROCM_MAJOR INSTALL_DIR RBT_BIN
+}
+
+ssh_state_paths() {
+  local base="${RUNNER_TEMP:-/tmp}"
+  SSH_KEY_FILE="${base}/rbt_target_key"
+  SSH_CONFIG_FILE="${base}/rbt_target_ssh_config"
+  mkdir -p "$base"
+}
+
+cmd_setup_ssh() {
+  require_env TARGET_NODE
+  require_env REMOTE_WORK_DIR
+
+  ssh_state_paths
+
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    {
+      echo "SSH_KEY_FILE=$SSH_KEY_FILE"
+      echo "SSH_CONFIG_FILE=$SSH_CONFIG_FILE"
+    } >> "$GITHUB_ENV"
+  fi
+
+  if [ -z "${SSH_PRIVATE_KEY:-}" ]; then
+    echo "::error::SSH_PRIVATE_KEY is not set; cannot SSH to target node." >&2
+    exit 1
+  fi
+
+  install -m 600 /dev/null "$SSH_KEY_FILE"
+  printf '%s\n' "$SSH_PRIVATE_KEY" > "$SSH_KEY_FILE"
+  chmod 600 "$SSH_KEY_FILE"
+
+  local known_hosts="${SSH_CONFIG_FILE}.known_hosts"
+  : > "$known_hosts"
+  chmod 600 "$known_hosts"
+  ssh-keyscan -T 15 -H "$TARGET_NODE" >> "$known_hosts" 2>/dev/null || true
+
+  cat > "$SSH_CONFIG_FILE" <<EOF
+Host rbt-target
+  HostName $TARGET_NODE
+  User ${TARGET_USER:-}
+  IdentityFile $SSH_KEY_FILE
+  IdentitiesOnly yes
+  BatchMode yes
+  LogLevel ERROR
+  StrictHostKeyChecking accept-new
+  UserKnownHostsFile $known_hosts
+  ServerAliveInterval 30
+  ServerAliveCountMax 10
+EOF
+  chmod 600 "$SSH_CONFIG_FILE"
+
+  echo "Verifying SSH connectivity to ${TARGET_USER:-}@${TARGET_NODE}..."
+  if ! ssh -F "$SSH_CONFIG_FILE" rbt-target 'echo __START__; hostname; id; uptime' \
+    2>&1 | sed -n '/^__START__$/,$p' | tail -n +2; then
+    echo "::error::SSH connectivity check failed for ${TARGET_USER:-}@${TARGET_NODE}. Verify secrets RBT_TARGET_NODE, RBT_TARGET_USER, RBT_TARGET_SSH_KEY and network access from this runner." >&2
+    exit 1
+  fi
+
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+    "mkdir -p '${REMOTE_WORK_DIR}/pkg' '${REMOTE_WORK_DIR}/reports'"
+}
+
+cmd_verify_rocm() {
+  require_env SSH_CONFIG_FILE
+  require_env TARGET_ROCM_PATH
+
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+    "TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
+set -euo pipefail
+echo "=== System ==="
+uname -a
+echo
+echo "=== Target ROCm path: ${TARGET_ROCM_PATH} ==="
+if [ ! -d "${TARGET_ROCM_PATH}" ]; then
+  echo "::error::${TARGET_ROCM_PATH} does not exist on the target node."
+  exit 1
+fi
+echo "=== ${TARGET_ROCM_PATH}/bin/rocminfo ==="
+"${TARGET_ROCM_PATH}/bin/rocminfo"
+echo
+echo "=== ${TARGET_ROCM_PATH}/bin/amd-smi version ==="
+"${TARGET_ROCM_PATH}/bin/amd-smi" version || echo "amd-smi not available"
+echo
+echo "::notice::ROCm prerequisites OK on target node at ${TARGET_ROCM_PATH}"
+REMOTE
+}
+
+cmd_download_tarball() {
+  require_env TARBALL_URL
+  require_env TARBALL_NAME
+  mkdir -p ./pkg
+  echo "Downloading: $TARBALL_URL"
+  curl -fL --max-time 600 -o "./pkg/${TARBALL_NAME}" "${TARBALL_URL}"
+  ls -la ./pkg/
+  file "./pkg/${TARBALL_NAME}" || true
+}
+
+cmd_copy_to_target() {
+  require_env SSH_CONFIG_FILE
+  require_env TARBALL_NAME
+  require_env REMOTE_WORK_DIR
+  echo "Copying ./pkg/${TARBALL_NAME} -> rbt-target:${REMOTE_WORK_DIR}/pkg/"
+  scp -q -F "$SSH_CONFIG_FILE" "./pkg/${TARBALL_NAME}" \
+    "rbt-target:${REMOTE_WORK_DIR}/pkg/${TARBALL_NAME}"
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target "ls -la '${REMOTE_WORK_DIR}/pkg/'"
+}
+
+cmd_install_rbt() {
+  require_env SSH_CONFIG_FILE
+  require_env TARBALL_NAME
+  require_env REMOTE_WORK_DIR
+  require_env ROCM_MAJOR
+  require_env INSTALL_DIR
+  require_env RBT_BIN
+  require_env TARGET_ROCM_PATH
+
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+    "TARBALL_NAME='$TARBALL_NAME' REMOTE_WORK_DIR='$REMOTE_WORK_DIR' ROCM_MAJOR='$ROCM_MAJOR' INSTALL_DIR='$INSTALL_DIR' RBT_BIN='$RBT_BIN' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
+set -euo pipefail
+PKG="${REMOTE_WORK_DIR}/pkg/${TARBALL_NAME}"
+echo "Target ROCm path            : ${TARGET_ROCM_PATH}"
+echo "Detected ROCm major version : ${ROCM_MAJOR}"
+echo "Install target              : ${INSTALL_DIR}"
+echo "Expected RBT binary         : ${RBT_BIN}"
+if [ ! -f "$PKG" ]; then
+  echo "::error::Tarball not found on target node at $PKG"
+  exit 1
+fi
+probe="$INSTALL_DIR"
+while [ ! -d "$probe" ] && [ "$probe" != "/" ]; do probe=$(dirname "$probe"); done
+if [ -w "$probe" ]; then
+  echo "Installing into $INSTALL_DIR without sudo (writable path)"
+  mkdir -p "$INSTALL_DIR"
+  tar -xzf "$PKG" -C "$INSTALL_DIR"
+else
+  echo "Installing into $INSTALL_DIR via sudo -n (path not user-writable)"
+  sudo -n mkdir -p "$INSTALL_DIR"
+  sudo -n tar -xzf "$PKG" -C "$INSTALL_DIR"
+fi
+if [ ! -x "$RBT_BIN" ]; then
+  echo "::error::rocm_bandwidth_test binary not found or not executable at $RBT_BIN after install"
+  ls -la "$INSTALL_DIR/" || true
+  ls -la "$INSTALL_DIR/bin/" || true
+  exit 1
+fi
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+echo "Installed RBT at: $RBT_BIN"
+"$RBT_BIN" --version || true
+REMOTE
+}
+
+cmd_verify_rbt_binary() {
+  require_env SSH_CONFIG_FILE
+  require_env RBT_BIN
+  require_env INSTALL_DIR
+  require_env TARGET_ROCM_PATH
+
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+    "RBT_BIN='$RBT_BIN' INSTALL_DIR='$INSTALL_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
+set -euo pipefail
+if [ ! -x "$RBT_BIN" ]; then
+  echo "::error::$RBT_BIN was not produced by tarball extraction on target."
+  exit 1
+fi
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+echo "=== ldd $RBT_BIN ==="
+LDD_OUTPUT=$(ldd "$RBT_BIN" 2>&1 || true)
+echo "$LDD_OUTPUT"
+if echo "$LDD_OUTPUT" | grep -q "not found"; then
+  echo "::error::RBT binary has unresolved library dependencies on target (see above)."
+  exit 1
+fi
+echo "::notice::RBT binary's library dependencies resolved OK on target."
+REMOTE
+}
+
+cmd_run_tests() {
+  require_env SSH_CONFIG_FILE
+  require_env RBT_BIN
+  require_env INSTALL_DIR
+  require_env REMOTE_WORK_DIR
+  require_env TARGET_ROCM_PATH
+  require_env TARGET_NODE
+
+  set +e
+  local rc_hc rc_p2p rc_topo
+  local start_hc end_hc start_p2p end_p2p start_topo end_topo
+
+  # ── Healthcheck ──────────────────────────────────────────────────────────
+  start_hc=$(date -u +%FT%TZ)
+  echo "::group::TransferBench healthcheck (${RBT_BIN} run transferbench healthcheck) on ${TARGET_NODE}"
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+    "RBT_BIN='$RBT_BIN' INSTALL_DIR='$INSTALL_DIR' REMOTE_WORK_DIR='$REMOTE_WORK_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
+set +e
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+mkdir -p "${REMOTE_WORK_DIR}/reports"
+"$RBT_BIN" run transferbench healthcheck --verbose 2>&1 | tee "${REMOTE_WORK_DIR}/reports/healthcheck.log"
+RC=${PIPESTATUS[0]}
+echo "remote_rc=$RC"
+exit $RC
+REMOTE
+  rc_hc=$?
+  echo "::endgroup::"
+  end_hc=$(date -u +%FT%TZ)
+
+  # ── P2P bandwidth ────────────────────────────────────────────────────────
+  start_p2p=$(date -u +%FT%TZ)
+  echo "::group::TransferBench P2P bandwidth (${RBT_BIN} run transferbench p2p) on ${TARGET_NODE}"
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+    "RBT_BIN='$RBT_BIN' INSTALL_DIR='$INSTALL_DIR' REMOTE_WORK_DIR='$REMOTE_WORK_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
+set +e
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+mkdir -p "${REMOTE_WORK_DIR}/reports"
+"$RBT_BIN" run transferbench p2p --size=256MB --iterations=10 2>&1 | tee "${REMOTE_WORK_DIR}/reports/p2p.log"
+RC=${PIPESTATUS[0]}
+echo "remote_rc=$RC"
+exit $RC
+REMOTE
+  rc_p2p=$?
+  echo "::endgroup::"
+  end_p2p=$(date -u +%FT%TZ)
+
+  # ── Topology ─────────────────────────────────────────────────────────────
+  start_topo=$(date -u +%FT%TZ)
+  echo "::group::TransferBench topology (${RBT_BIN} run transferbench topology) on ${TARGET_NODE}"
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+    "RBT_BIN='$RBT_BIN' INSTALL_DIR='$INSTALL_DIR' REMOTE_WORK_DIR='$REMOTE_WORK_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
+set +e
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+mkdir -p "${REMOTE_WORK_DIR}/reports"
+"$RBT_BIN" run transferbench topology 2>&1 | tee "${REMOTE_WORK_DIR}/reports/topology.log"
+RC=${PIPESTATUS[0]}
+echo "remote_rc=$RC"
+exit $RC
+REMOTE
+  rc_topo=$?
+  echo "::endgroup::"
+  end_topo=$(date -u +%FT%TZ)
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "rc_healthcheck=$rc_hc"
+      echo "start_healthcheck=$start_hc"
+      echo "end_healthcheck=$end_hc"
+      echo "rc_p2p=$rc_p2p"
+      echo "start_p2p=$start_p2p"
+      echo "end_p2p=$end_p2p"
+      echo "rc_topology=$rc_topo"
+      echo "start_topology=$start_topo"
+      echo "end_topology=$end_topo"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  # Caller workflow decides whether to fail the job on non-zero rc.
+  return 0
+}
+
+cmd_collect_logs() {
+  require_env SSH_CONFIG_FILE
+  require_env REMOTE_WORK_DIR
+  mkdir -p ./reports
+  if [ ! -f "$SSH_CONFIG_FILE" ]; then
+    echo "::warning::SSH config not present; skipping log collection."
+    return 0
+  fi
+  echo "Copying logs from rbt-target:${REMOTE_WORK_DIR}/reports/ -> ./reports/"
+  scp -q -F "$SSH_CONFIG_FILE" "rbt-target:${REMOTE_WORK_DIR}/reports/*.log" ./reports/ || \
+    echo "::warning::No log files retrieved from target node."
+  ls -la ./reports/ || true
+}
+
+cmd_capture_versions() {
+  require_env SSH_CONFIG_FILE
+  require_env RBT_BIN
+  require_env INSTALL_DIR
+  require_env TARGET_ROCM_PATH
+
+  local rbt_version target_rocm_version
+  rbt_version=$(
+    ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+      "RBT_BIN='$RBT_BIN' INSTALL_DIR='$INSTALL_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE' 2>/dev/null | head -1 || echo "unknown"
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
+"$RBT_BIN" --version 2>/dev/null
+REMOTE
+  )
+  target_rocm_version=$(
+    ssh -q -F "$SSH_CONFIG_FILE" rbt-target \
+      "TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE' 2>/dev/null || echo "unknown"
+cat "${TARGET_ROCM_PATH}/.info/version" 2>/dev/null \
+  || cat "${TARGET_ROCM_PATH}/share/doc/rocm-core/version" 2>/dev/null \
+  || echo "unknown"
+REMOTE
+  )
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "rbt_version=$rbt_version" >> "$GITHUB_OUTPUT"
+    echo "target_rocm_version=$target_rocm_version" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+cmd_build_report() {
+  require_env TARBALL_NAME
+  require_env TARBALL_URL
+  require_env TARGET_ROCM_PATH
+  require_env REMOTE_WORK_DIR
+  require_env RBT_BIN
+
+  local rc_hc="${RBT_HEALTHCHECK_RC:-0}"
+  local rc_p2p="${RBT_P2P_RC:-0}"
+  local rc_topo="${RBT_TOPOLOGY_RC:-0}"
+  local start_hc="${RBT_HEALTHCHECK_START:-}"
+  local end_hc="${RBT_HEALTHCHECK_END:-}"
+  local start_p2p="${RBT_P2P_START:-}"
+  local end_p2p="${RBT_P2P_END:-}"
+  local start_topo="${RBT_TOPOLOGY_START:-}"
+  local end_topo="${RBT_TOPOLOGY_END:-}"
+  local rbt_version="${RBT_VERSION:-unknown}"
+  local target_rocm_version="${TARGET_ROCM_VERSION:-unknown}"
+  local run_id="${GITHUB_RUN_ID:-local}"
+  local server_url="${GITHUB_SERVER_URL:-https://github.com}"
+  local repository="${GITHUB_REPOSITORY:-local/repo}"
+  local event_name="${GITHUB_EVENT_NAME:-local}"
+
+  mkdir -p ./reports
+
+  local s_hc s_p2p s_topo overall
+  [ "$rc_hc"   -eq 0 ] && s_hc=PASS   || s_hc=FAIL
+  [ "$rc_p2p"  -eq 0 ] && s_p2p=PASS  || s_p2p=FAIL
+  [ "$rc_topo" -eq 0 ] && s_topo=PASS || s_topo=FAIL
+
+  if [ "$rc_hc" -eq 0 ] && [ "$rc_p2p" -eq 0 ] && [ "$rc_topo" -eq 0 ]; then
+    overall=PASS
+  else
+    overall=FAIL
+  fi
+
+  local report=./reports/SUMMARY.md
+  {
+    echo "# RBT Nightly Test Report"
+    echo ""
+    echo "| Field | Value |"
+    echo "|---|---|"
+    echo "| Run | [\`${run_id}\`](${server_url}/${repository}/actions/runs/${run_id}) |"
+    echo "| Trigger | \`${event_name}\` |"
+    echo "| Target ROCm path | \`${TARGET_ROCM_PATH}\` (version \`${target_rocm_version}\`) |"
+    echo "| Remote work dir | \`${REMOTE_WORK_DIR}\` |"
+    echo "| Tarball | \`${TARBALL_NAME}\` |"
+    echo "| Source URL | ${TARBALL_URL} |"
+    echo "| RBT version | \`${rbt_version}\` |"
+    echo "| Overall result | **${overall}** |"
+    echo ""
+    echo "## Results"
+    echo ""
+    echo "| Test | Command | Result | Exit | Started (UTC) | Ended (UTC) |"
+    echo "|---|---|:--:|---:|---|---|"
+    echo "| Healthcheck | \`${RBT_BIN} run transferbench healthcheck\` | ${s_hc} | ${rc_hc} | ${start_hc} | ${end_hc} |"
+    echo "| P2P Bandwidth | \`${RBT_BIN} run transferbench p2p --size=256MB --iterations=10\` | ${s_p2p} | ${rc_p2p} | ${start_p2p} | ${end_p2p} |"
+    echo "| Topology | \`${RBT_BIN} run transferbench topology\` | ${s_topo} | ${rc_topo} | ${start_topo} | ${end_topo} |"
+    echo ""
+    echo "## Logs"
+    echo ""
+    echo "Full stdout/stderr from test runs is attached to the artifact"
+    echo "\`rbt-nightly-report-${run_id}\`:"
+    echo ""
+    echo "- \`healthcheck.log\`"
+    echo "- \`p2p.log\`"
+    echo "- \`topology.log\`"
+    echo "- \`SUMMARY.md\` (this file)"
+  } > "$report"
+
+  cat "$report"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    cat "$report" >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "overall=$overall" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+cmd_cleanup_remote() {
+  set +e
+  if [ -z "${REMOTE_WORK_DIR:-}" ] || [ -z "${SSH_CONFIG_FILE:-}" ] || [ ! -f "$SSH_CONFIG_FILE" ]; then
+    return 0
+  fi
+  ssh -q -F "$SSH_CONFIG_FILE" rbt-target "rm -rf '${REMOTE_WORK_DIR}'" || \
+    echo "::warning::Failed to clean up ${REMOTE_WORK_DIR} on target node."
+}
+
+cmd_cleanup_local_ssh() {
+  set +e
+  if [ -n "${SSH_KEY_FILE:-}" ]; then
+    rm -f "$SSH_KEY_FILE"
+  fi
+  if [ -n "${SSH_CONFIG_FILE:-}" ]; then
+    rm -f "$SSH_CONFIG_FILE" "${SSH_CONFIG_FILE}.known_hosts"
+  fi
+}
+
+main() {
+  if [ $# -lt 1 ]; then
+    usage
+    exit 1
+  fi
+  case "$1" in
+    validate-config)    cmd_validate_config ;;
+    setup-ssh)          cmd_setup_ssh ;;
+    verify-rocm)        cmd_verify_rocm ;;
+    download-tarball)   cmd_download_tarball ;;
+    copy-to-target)     cmd_copy_to_target ;;
+    install-rbt)        cmd_install_rbt ;;
+    verify-rbt-binary)  cmd_verify_rbt_binary ;;
+    run-tests)          cmd_run_tests ;;
+    collect-logs)       cmd_collect_logs ;;
+    capture-versions)   cmd_capture_versions ;;
+    build-report)       cmd_build_report ;;
+    cleanup-remote)     cmd_cleanup_remote ;;
+    cleanup-local-ssh)  cmd_cleanup_local_ssh ;;
+    -h|--help)          usage ;;
+    *)
+      echo "::error::Unknown command: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Fix git artifact folders/files

## Motivation/Commit message body 

Nightly build packages were all landing in a single S3 prefix (nightly/rbt/deb) regardless of package type. This made it hard to consume DEB, RPM, and TGZ packages from separate, type-specific S3 bucket paths and broke any downstream tooling that expects a clean separation between package formats and channels


## Technical Details

Introduced `.github/scripts/rbt-s3-upload-route.sh`, a **POSIX shell script** that centralizes all S3 path resolution logic for RBT package uploads. The script resolves the correct S3 prefix per package type and CI event, replacing the previously inline and inconsistent routing in the workflow YAML

S3 folder structure is now enforced as:
  - nightly/rbt/deb -> Debian packages (**Ubuntu 22.04 build**)
  - nightly/rbt/rpm -> RPM packages (**manylinux_2_28 build**)
  - nightly/rbt/tar -> Relocatable tarballs (**manylinux_2_28 build**, `glibc 2.28`, portable across **RHEL 8+** and **Ubuntu 20.04+**)
  - release/rbt/{deb,rpm,tar} -> Same structure for release branch builds

The **Ubuntu** job uploads only DEBs to S3. The **manylinux** job uploads RPMs and the canonical TGZ. 
This avoids a collision where both jobs would otherwise produce a TGZ to the same S3 key with different `glibc`  
requirements

The `build-relocatable-packages.yml` was updated to invoke the routing script for all upload and **repodata** generation steps


## Test Plan

- **Local smoke test:** invoked `rbt-s3-upload-route.sh` with mocked `GITHUB_EVENT_NAME`, `GITHUB_REF`, and empty `AWS_S3_BUCKET` for all four commands (`upload-deb, upload-rpm-tar, deb-repo-prefix, rpm-repo-prefix`)
across nightly, release, and PR event scenarios, verifying correct prefix resolution without S3 writes
- **Full E2E:** triggered workflow_dispatch from this feature branch against the real S3 bucket, confirming packages were uploaded to the correct type-separated prefixes


## Test Result

- Local routing smoke test passed for all event types and all package type prefixes
- E2E run confirmed `nightly/rbt/deb`, `nightly/rbt/rpm`, and `nightly/rbt/tar` are populated with the correct package files in the S3 bucket
- Release path verified locally: `deb-repo-prefix` returns `release/rbt/deb + rbt-release`; `rpm-repo-prefix` returns `release/rbt/rpm`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
