### PR TITLE
build: Filter out 'ADHOCBUILD-*' versions

### DIFF
--- a/.github/scripts/configure-rocm-sdk-channel.sh
+++ b/.github/scripts/configure-rocm-sdk-channel.sh
@@ -9,8 +9,8 @@ GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
 
 NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-}"
 NIGHTLY_IDX="${ROCM_SDK_NIGHTLY_INDEX_URL:-}"
-[ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://therock-nightly-tarball.s3.us-east-2.amazonaws.com'
-[ -z "$NIGHTLY_IDX" ]  && NIGHTLY_IDX='https://therock-nightly-tarball.s3.amazonaws.com/index.html'
+[ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
+[ -z "$NIGHTLY_IDX" ]  && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
 
 REL_URL="${ROCM_SDK_RELEASE_URL:-}"
 [ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -24,7 +24,7 @@ on:
       - develop
       - amd-mainline
   schedule:
-    # Run daily at 1:00 PM UTC (nightly builds)
+    # Run daily at 7:00 AM CST (13:00 UTC; CST is UTC-6) nightly builds
     - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -135,6 +135,7 @@ fetch_latest_rocm_version() {
     local latest_version
     latest_version=$(wget -qO- "$ROCM_SDK_INDEX_URL" 2>/dev/null | \
         grep -oP "therock-dist-linux-${gpu_family}-\K[^<\"]+(?=\.tar\.gz)" | \
+        grep -v '^ADHOCBUILD' | \
         sort -V | tail -1)
 
     if [ -z "$latest_version" ]; then


### PR DESCRIPTION
1. Script adjusted to filter out ROCM_VERSION versions like:
- `ADHOCBUILD-7.0.0rc20250625`

Which would cause errors like:
'''
[INFO] Step 2: Setting up ROCm environment...
[INFO] Locating HIP device libraries (amdgcn/bitcode)...

Error: Process completed with exit code 1.
'''

2. Fix ROCm download stream
- https://rocm.nightlies.amd.com/tarball-multi-arch

Code changes related to the following:
  * build (shell) script

## Motivation

The nightly SDK index at `therock-nightly-tarball.s3.amazonaws.com` began publishing entries with version strings prefixed by `ADHOCBUILD- (e.g. ADHOCBUILD-7.0.0rc20250625)`. **These are not valid semver strings** and caused `sort -V | tail -1` to select them as "latest", producing a version token the build script could not resolve to a real tarball

This triggered a failure at: **Step 2 (Locating HIP device libraries (amdgcn/bitcode)) with exit code 1.**
Also, the nightly tarball source has migrated from the direct S3 endpoints to `rocm.nightlies.amd.com/tarball-multi-arch`


## Technical Details

Changes:
- `build_packages_local.sh`: Added `grep -v '^ADHOCBUILD'` to the `fetch_latest_rocm_version()` pipeline, between the version extraction `grep` and `sort -V | tail -1`. This filters out any `ADHOCBUILD-*` tokens before version selection
- `.github/scripts/configure-rocm-sdk-channel.sh`: Updated the nightly URL defaults:
  - **NIGHTLY_BASE:** `https://therock-nightly-tarball.s3.us-east-2.amazonaws.com` -> `https://rocm.nightlies.amd.com/tarball-multi-arch`
  - **NIGHTLY_IDX:** `https://therock-nightly-tarball.s3.amazonaws.com/index.html` -> `https://rocm.nightlies.amd.com/tarball-multi-arch/`

These defaults apply only when the corresponding repo variables (`ROCM_SDK_NIGHTLY_BASE_URL`, `ROCM_SDK_NIGHTLY_INDEX_URL`) are not set.


## Test Plan

- Ran `build_packages_local.sh` locally against the nightly index while `ADHOCBUILD-*` entries were present in the index and confirmed the filter strips them and a valid **semver version** is selected.
-  Triggered the **Build Relocatable Packages GitHub Actions workflow against this branch** and both the Ubuntu (DEB/TGZ) and CentOS/RHEL (RPM/TGZ) jobs completed successfully

## Test Result

Local build and branch workflow run passed. DEB, RPM, and TGZ packages were generated and verified successfully

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
